### PR TITLE
Add aggregation endpoint

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/SpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/SpecimenController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RequestMapping("/api/v1/specimens")
 @RequiredArgsConstructor
 public class SpecimenController {
+
   private final SpecimenService service;
 
   @ResponseStatus(HttpStatus.OK)
@@ -50,7 +51,8 @@ public class SpecimenController {
   @GetMapping(value = "/latest", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> getLatestSpecimen(
       @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
-      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize, HttpServletRequest request) throws IOException {
+      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize, HttpServletRequest request)
+      throws IOException {
     log.info("Received get request for latest digital specimen");
     var path = SANDBOX_URI + request.getRequestURI();
     var specimens = service.getLatestSpecimen(pageNumber, pageSize, path);
@@ -81,7 +83,8 @@ public class SpecimenController {
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/full", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> getSpecimenByIdFull(
-      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix, HttpServletRequest request) {
+      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
+      HttpServletRequest request) {
     var id = prefix + '/' + suffix;
     log.info("Received get request for specimen with id: {}", id);
     var path = SANDBOX_URI + request.getRequestURI();
@@ -92,7 +95,8 @@ public class SpecimenController {
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/{version}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> getSpecimenByVersion(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix, @PathVariable("version") int version, HttpServletRequest request)
+      @PathVariable("suffix") String suffix, @PathVariable("version") int version,
+      HttpServletRequest request)
       throws JsonProcessingException, NotFoundException, UnprocessableEntityException {
     var id = prefix + '/' + suffix;
     log.info("Received get request for specimen with id and version: {}", id);
@@ -115,7 +119,8 @@ public class SpecimenController {
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/annotations", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> getSpecimenAnnotations(
-      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix, HttpServletRequest request) {
+      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
+      HttpServletRequest request) {
     var id = prefix + '/' + suffix;
     log.info("Received get request for annotations of specimen with id: {}", id);
     var path = SANDBOX_URI + request.getRequestURI();
@@ -126,7 +131,8 @@ public class SpecimenController {
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/digitalmedia", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> getSpecimenDigitalMedia(
-      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix, HttpServletRequest request) {
+      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
+      HttpServletRequest request) {
     var id = prefix + '/' + suffix;
     log.info("Received get request for digitalmedia of specimen with id: {}", id);
     var path = SANDBOX_URI + request.getRequestURI();
@@ -145,4 +151,16 @@ public class SpecimenController {
     return ResponseEntity.ok(specimen);
   }
 
+  @ResponseStatus(HttpStatus.OK)
+  @GetMapping(value = "aggregation", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonApiWrapper> aggregation(
+      @RequestParam MultiValueMap<String, String> params, HttpServletRequest request)
+      throws IOException, UnknownParameterException {
+    log.info("Request for aggregations");
+    var path = SANDBOX_URI + request.getRequestURI() + "?" + request.getQueryString();
+    var aggregations = service.aggregations(params, path);
+    return ResponseEntity.ok(aggregations);
+  }
 }
+
+

--- a/src/main/java/eu/dissco/backend/domain/MappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/MappingTerms.java
@@ -1,0 +1,70 @@
+package eu.dissco.backend.domain;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public enum MappingTerms {
+  COUNTRY("country", "digitalSpecimen.ods:attributes.dwc:country.keyword"),
+  COUNTRY_CODE("countryCode", "digitalSpecimen.ods:attributes.dwc:countryCode.keyword"),
+  MIDS_LEVEL("midsLevel", "midsLevel"),
+  PHYSICAL_SPECIMEN_ID("physicalSpecimenId", "digitalSpecimen.ods:physicalSpecimenId.keyword"),
+  TYPE_STATUS("typeStatus", "digitalSpecimen.ods:attributes.dwc:typeStatus.keyword"),
+  LICENSE("license", "digitalSpecimen.ods:attributes.dcterms:license.keyword"),
+  HAS_MEDIA("hasMedia", "digitalSpecimen.ods:attributes.ods:hasMedia.keyword"),
+  ORGANISATION_ID("organisationId", "digitalSpecimen.ods:attributes.ods:organisationId.keyword"),
+  ORGANISATION_NAME("organisationName",
+      "digitalSpecimen.ods:attributes.ods:organisationName.keyword"),
+  SOURCE_SYSTEM_ID("sourceSystemId", "digitalSpecimen.ods:attributes.ods:sourceSystemId.keyword"),
+  SPECIMEN_NAME("type", "digitalSpecimen.ods:type.keyword"),
+  DATASET_ID("datasetId", "digitalSpecimen.ods:attributes.ods:datasetId.keyword"),
+  QUERY("q", "q");
+
+  private final String name;
+  private final String fullName;
+
+  MappingTerms(String name, String fullName) {
+    this.name = name;
+    this.fullName = fullName;
+  }
+
+  public static Map<String, String> getParamMapping() {
+    var paramMap = new HashMap<String, String>();
+    paramMap.put(COUNTRY.name, COUNTRY.fullName);
+    paramMap.put(COUNTRY_CODE.name, COUNTRY_CODE.fullName);
+    paramMap.put(MIDS_LEVEL.name, MIDS_LEVEL.fullName);
+    paramMap.put(PHYSICAL_SPECIMEN_ID.name, PHYSICAL_SPECIMEN_ID.fullName);
+    paramMap.put(TYPE_STATUS.name, TYPE_STATUS.fullName);
+    paramMap.put(LICENSE.name, LICENSE.fullName);
+    paramMap.put(HAS_MEDIA.name, HAS_MEDIA.fullName);
+    paramMap.put(ORGANISATION_ID.name, ORGANISATION_NAME.fullName);
+    paramMap.put(ORGANISATION_NAME.name, ORGANISATION_NAME.fullName);
+    paramMap.put(SOURCE_SYSTEM_ID.name, SOURCE_SYSTEM_ID.fullName);
+    paramMap.put(SPECIMEN_NAME.name, SPECIMEN_NAME.fullName);
+    paramMap.put(QUERY.name, QUERY.fullName);
+    return paramMap;
+  }
+
+  public static List<MappingTerms> getAggregationList() {
+    var aggregationTerms = new ArrayList<MappingTerms>();
+    aggregationTerms.add(COUNTRY);
+    aggregationTerms.add(MIDS_LEVEL);
+    aggregationTerms.add(TYPE_STATUS);
+    aggregationTerms.add(LICENSE);
+    aggregationTerms.add(HAS_MEDIA);
+    aggregationTerms.add(ORGANISATION_NAME);
+    aggregationTerms.add(SOURCE_SYSTEM_ID);
+    aggregationTerms.add(DATASET_ID);
+    return aggregationTerms;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getFullName() {
+    return fullName;
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/domain/MappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/MappingTerms.java
@@ -1,9 +1,10 @@
 package eu.dissco.backend.domain;
 
-import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public enum MappingTerms {
   COUNTRY("country", "digitalSpecimen.ods:attributes.dwc:country.keyword"),
@@ -21,6 +22,8 @@ public enum MappingTerms {
   DATASET_ID("datasetId", "digitalSpecimen.ods:attributes.ods:datasetId.keyword"),
   QUERY("q", "q");
 
+  public static final Set<MappingTerms> aggregationList = getAggregationList();
+  private static final Map<String, String> paramMapping = getParamMapping();
   private final String name;
   private final String fullName;
 
@@ -29,7 +32,24 @@ public enum MappingTerms {
     this.fullName = fullName;
   }
 
-  public static Map<String, String> getParamMapping() {
+  public static Optional<String> getMappedTerm(String name) {
+    return Optional.ofNullable(paramMapping.get(name));
+  }
+
+  private static Set<MappingTerms> getAggregationList() {
+    var aggregationTerms = EnumSet.noneOf(MappingTerms.class);
+    aggregationTerms.add(COUNTRY);
+    aggregationTerms.add(MIDS_LEVEL);
+    aggregationTerms.add(TYPE_STATUS);
+    aggregationTerms.add(LICENSE);
+    aggregationTerms.add(HAS_MEDIA);
+    aggregationTerms.add(ORGANISATION_NAME);
+    aggregationTerms.add(SOURCE_SYSTEM_ID);
+    aggregationTerms.add(DATASET_ID);
+    return aggregationTerms;
+  }
+
+  private static Map<String, String> getParamMapping() {
     var paramMap = new HashMap<String, String>();
     paramMap.put(COUNTRY.name, COUNTRY.fullName);
     paramMap.put(COUNTRY_CODE.name, COUNTRY_CODE.fullName);
@@ -44,19 +64,6 @@ public enum MappingTerms {
     paramMap.put(SPECIMEN_NAME.name, SPECIMEN_NAME.fullName);
     paramMap.put(QUERY.name, QUERY.fullName);
     return paramMap;
-  }
-
-  public static List<MappingTerms> getAggregationList() {
-    var aggregationTerms = new ArrayList<MappingTerms>();
-    aggregationTerms.add(COUNTRY);
-    aggregationTerms.add(MIDS_LEVEL);
-    aggregationTerms.add(TYPE_STATUS);
-    aggregationTerms.add(LICENSE);
-    aggregationTerms.add(HAS_MEDIA);
-    aggregationTerms.add(ORGANISATION_NAME);
-    aggregationTerms.add(SOURCE_SYSTEM_ID);
-    aggregationTerms.add(DATASET_ID);
-    return aggregationTerms;
   }
 
   public String getName() {

--- a/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
@@ -1,5 +1,6 @@
 package eu.dissco.backend.repository;
 
+import static eu.dissco.backend.domain.MappingTerms.aggregationList;
 import static eu.dissco.backend.repository.RepositoryUtils.getOffset;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -18,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.backend.domain.AnnotationResponse;
 import eu.dissco.backend.domain.DigitalSpecimen;
-import eu.dissco.backend.domain.MappingTerms;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -149,7 +148,7 @@ public class ElasticSearchRepository {
   public Map<String, Map<String, Long>> getAggregations(Map<String, List<String>> params) throws IOException {
     var aggregationQueries = new HashMap<String, Aggregation>();
     var queries = generateQueries(params);
-    for (var aggregationTerm : MappingTerms.getAggregationList()) {
+    for (var aggregationTerm : aggregationList) {
       aggregationQueries.put(aggregationTerm.getName(), AggregationBuilders.terms()
           .field(aggregationTerm.getFullName()).build()._toAggregation());
     }

--- a/src/main/java/eu/dissco/backend/service/SpecimenService.java
+++ b/src/main/java/eu/dissco/backend/service/SpecimenService.java
@@ -1,5 +1,6 @@
 package eu.dissco.backend.service;
 
+import static eu.dissco.backend.domain.MappingTerms.getMappedTerm;
 import static eu.dissco.backend.service.ServiceUtils.createVersionNode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,7 +10,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.backend.domain.DigitalSpecimen;
 import eu.dissco.backend.domain.DigitalSpecimenFull;
 import eu.dissco.backend.domain.DigitalSpecimenJsonLD;
-import eu.dissco.backend.domain.MappingTerms;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
@@ -254,9 +254,9 @@ public class SpecimenService {
       throws UnknownParameterException {
     var mappedParams = new HashMap<String, List<String>>();
     for (var entry : params.entrySet()) {
-      var mappedParam = MappingTerms.getParamMapping().get(entry.getKey());
-      if (mappedParam != null) {
-        mappedParams.put(mappedParam, entry.getValue());
+      var mappedParam = getMappedTerm(entry.getKey());
+      if (mappedParam.isPresent()) {
+        mappedParams.put(mappedParam.get(), entry.getValue());
       } else {
         throw new UnknownParameterException("Parameter: " + entry.getKey() + " is not recognised");
       }

--- a/src/main/java/eu/dissco/backend/service/SpecimenService.java
+++ b/src/main/java/eu/dissco/backend/service/SpecimenService.java
@@ -196,15 +196,20 @@ public class SpecimenService {
 
   private JsonApiListResponseWrapper wrapListResponse(List<DigitalSpecimen> digitalSpecimenList,
       int pageSize, int pageNumber, String path) {
-    var dataNodePlusOne = digitalSpecimenList.stream().map(specimen -> new JsonApiData(specimen.id(), specimen.type(), specimen, mapper)).toList();
+    var dataNodePlusOne = digitalSpecimenList.stream()
+        .map(specimen -> new JsonApiData(specimen.id(), specimen.type(), specimen, mapper))
+        .toList();
     boolean hasNext = dataNodePlusOne.size() > pageSize;
     var linksNode = new JsonApiLinksFull(pageNumber, pageSize, hasNext, path);
     var dataNode = hasNext ? dataNodePlusOne.subList(0, pageSize) : dataNodePlusOne;
     return new JsonApiListResponseWrapper(dataNode, linksNode);
   }
+
   private JsonApiListResponseWrapper wrapListResponse(List<DigitalSpecimen> digitalSpecimenList,
       int pageNumber, int pageSize, MultiValueMap<String, String> params, String path) {
-    var dataNodePlusOne = digitalSpecimenList.stream().map(specimen -> new JsonApiData(specimen.id(), specimen.type(), specimen, mapper)).toList();
+    var dataNodePlusOne = digitalSpecimenList.stream()
+        .map(specimen -> new JsonApiData(specimen.id(), specimen.type(), specimen, mapper))
+        .toList();
     boolean hasNext = dataNodePlusOne.size() > pageSize;
     var linksNode = new JsonApiLinksFull(params, pageNumber, pageSize, hasNext, path);
     var dataNode = hasNext ? dataNodePlusOne.subList(0, pageSize) : dataNodePlusOne;
@@ -262,7 +267,8 @@ public class SpecimenService {
   public JsonApiWrapper aggregations(MultiValueMap<String, String> params, String path)
       throws IOException, UnknownParameterException {
     var aggregations = elasticRepository.getAggregations(mapParams(params));
-    var dataNode = new JsonApiData("id", "aggregations", mapper.valueToTree(aggregations));
+    var dataNode = new JsonApiData(String.valueOf(params.hashCode()), "aggregations",
+        mapper.valueToTree(aggregations));
     return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
   }
 }

--- a/src/test/java/eu/dissco/backend/TestUtils.java
+++ b/src/test/java/eu/dissco/backend/TestUtils.java
@@ -15,6 +15,7 @@ import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
 import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
 import java.time.Instant;
+import java.util.Map;
 
 public class TestUtils {
 
@@ -27,8 +28,12 @@ public class TestUtils {
   public static final String ID = PREFIX + "/" + SUFFIX;
   public static final String ID_ALT = PREFIX + "/" + "AAA-111-ZZZ";
   public static final String TARGET_ID = PREFIX + "/TAR_GET_001";
+  public static final String SOURCE_SYSTEM_ID_1 = "20.5000.1025/3XA-8PT-SAY";
+  public static final String SOURCE_SYSTEM_ID_2 = "20.5000.1025/ANO-THE-RAY";
 
   public static final ObjectMapper MAPPER;
+  public static final Instant CREATED = Instant.parse("2022-11-01T09:59:24.00Z");
+  public static final String SANDBOX_URI = "https://sandbox.dissco.tech";
 
   static {
     var mapper = new ObjectMapper().findAndRegisterModules();
@@ -39,9 +44,6 @@ public class TestUtils {
     mapper.setSerializationInclusion(Include.NON_NULL);
     MAPPER = mapper.copy();
   }
-  public static final Instant CREATED = Instant.parse("2022-11-01T09:59:24.00Z");
-
-  public static final String SANDBOX_URI = "https://sandbox.dissco.tech";
 
   // Users
   public static JsonApiWrapper givenUserResponse() {
@@ -86,10 +88,18 @@ public class TestUtils {
     return givenDigitalSpecimen(id, "global_id_123123");
   }
 
-  public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId) throws JsonProcessingException {
-    return givenDigitalSpecimen(id, physicalId, 1);
+  public static DigitalSpecimen givenDigitalSpecimenSourceSystem(String id, String sourceSystem)
+      throws JsonProcessingException {
+    return givenDigitalSpecimen(id, "global_id_123123", 1, sourceSystem);
   }
-  public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId, int version)
+
+  public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId)
+      throws JsonProcessingException {
+    return givenDigitalSpecimen(id, physicalId, 1, SOURCE_SYSTEM_ID_1);
+  }
+
+  public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId, int version,
+      String sourceSystemId)
       throws JsonProcessingException {
     return new DigitalSpecimen(
         id,
@@ -103,8 +113,8 @@ public class TestUtils {
         "https://ror.org/0349vqz63",
         "Royal Botanic Garden Edinburgh Herbarium",
         "http://biocol.org/urn:lsid:biocol.org:col:15670",
-        "20.5000.1025/3XA-8PT-SAY",
-        givenSpecimenData(),
+        sourceSystemId,
+        givenSpecimenData(sourceSystemId),
         givenSpecimenOriginalData(),
         "http://data.rbge.org.uk/herb/E00586417");
   }
@@ -141,21 +151,30 @@ public class TestUtils {
             """, JsonNode.class);
   }
 
-  private static JsonNode givenSpecimenData() throws JsonProcessingException {
-    return MAPPER.readValue(
-        """
-            {
-              "dwca:id": "http://data.rbge.org.uk/herb/E00586417",
-              "ods:modified": "03/12/2012",
-              "ods:datasetId": "Royal Botanic Garden Edinburgh Herbarium",
-              "ods:objectType": "",
-              "dcterms:license": "http://creativecommons.org/licenses/by/4.0/legalcode",
-              "ods:specimenName": "Leucanthemum ircutianum (Turcz.) Turcz.ex DC.",
-              "ods:organisationId": "https://ror.org/0349vqz63",
-              "ods:sourceSystemId": "20.5000.1025/3XA-8PT-SAY",
-              "ods:physicalSpecimenIdType": "cetaf",
-              "ods:physicalSpecimenCollection": "http://biocol.org/urn:lsid:biocol.org:col:15670"      
-            }
-            """, JsonNode.class);
+  private static JsonNode givenSpecimenData(String sourceSystemId) {
+    var node = MAPPER.createObjectNode();
+    node.put("dwca:id", "http://data.rbge.org.uk/herb/E00586417");
+    node.put("ods:modified", "03/12/2012");
+    node.put("ods:datasetId", "Royal Botanic Garden Edinburgh Herbarium");
+    node.put("ods:objectType", "");
+    node.put("dcterms:license", "http://creativecommons.org/licenses/by/4.0/legalcode");
+    node.put("ods:specimenName", "Leucanthemum ircutianum (Turcz.) Turcz.ex DC.");
+    node.put("ods:organisationId", "https://ror.org/0349vqz63");
+    node.put("ods:sourceSystemId", sourceSystemId);
+    node.put("ods:physicalSpecimenIdType", "cetaf");
+    node.put("ods:physicalSpecimenCollection", "http://biocol.org/urn:lsid:biocol.org:col:15670");
+    node.put("ods:specimenName", "Leucanthemum ircutianum (Turcz.) Turcz.ex DC.");
+    node.put("dwc:typeStatus", "holotype");
+    node.put("dwc:country", "Scotland");
+    node.put("ods:hasMedia", "true");
+    return node;
+  }
+
+  public static Map<String, Map<String, Long>> givenAggregationMap() {
+    return Map.of(
+        "sourceSystem", Map.of(SOURCE_SYSTEM_ID_1, 5L, SOURCE_SYSTEM_ID_2, 5L),
+        "typeStatus", Map.of("type", 10L),
+        "hasMedia", Map.of("true", 10L)
+    );
   }
 }

--- a/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
@@ -1,7 +1,10 @@
 package eu.dissco.backend.controller;
 
+import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.PREFIX;
+import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_1;
 import static eu.dissco.backend.TestUtils.SUFFIX;
+import static eu.dissco.backend.TestUtils.givenAggregationMap;
 import static eu.dissco.backend.utils.SpecimenUtils.SPECIMEN_URI;
 import static eu.dissco.backend.utils.SpecimenUtils.givenDigitalSpecimenJsonApiDataList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -9,7 +12,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+import eu.dissco.backend.domain.jsonapi.JsonApiData;
+import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
+import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.backend.service.SpecimenService;
 import java.util.List;
 import java.util.Map;
@@ -131,6 +137,22 @@ class SpecimenControllerTest {
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(((JsonApiListResponseWrapper) result.getBody()).getData()).isEqualTo(
         givenDigitalSpecimenJsonApiDataList(2));
+  }
+
+  @Test
+  void testAggregation() throws Exception {
+    //Given
+    var paramMap = new MultiValueMapAdapter(Map.of("SourceSystemId", List.of(SOURCE_SYSTEM_ID_1)));
+    var data = new JsonApiData("id", "aggregations", MAPPER.valueToTree(givenAggregationMap()));
+    given(service.aggregations(eq(paramMap), anyString())).willReturn(
+        new JsonApiWrapper(data, new JsonApiLinks("test")));
+
+    // When
+    var result = controller.aggregation(paramMap, mockRequest);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(((JsonApiWrapper) result.getBody()).data()).isEqualTo(data);
   }
 
 }

--- a/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
@@ -383,7 +383,7 @@ class SpecimenServiceTest {
     var map = new MultiValueMapAdapter<>(params);
     var aggregationMap = givenAggregationMap();
     given(elasticRepository.getAggregations(anyMap())).willReturn(aggregationMap);
-    var dataNode = new JsonApiData("id", "aggregations", MAPPER.valueToTree(aggregationMap));
+    var dataNode = new JsonApiData(String.valueOf(params.hashCode()), "aggregations", MAPPER.valueToTree(aggregationMap));
     var linksNode = new JsonApiLinks(SPECIMEN_PATH);
     var expected = new JsonApiWrapper(dataNode, linksNode);
 

--- a/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
@@ -4,7 +4,6 @@ import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.PREFIX;
 import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_1;
-import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_2;
 import static eu.dissco.backend.TestUtils.USER_ID_TOKEN;
 import static eu.dissco.backend.TestUtils.givenAggregationMap;
 import static eu.dissco.backend.TestUtils.givenDigitalSpecimen;


### PR DESCRIPTION
Adds a aggregation endpoint which returns the format.
Example query:
`localhost:8080/api/v1/specimens/aggregation?country=Finland&sourceSystemId=20.5000.1025/5N1-FST-J0E`
Returns the following format.
```{
    "data": {
        "id": "1145151679",
        "type": "aggregations",
        "attributes": {
            "midsLevel": {
                "0": 9
            },
            "license": {
                "CC0 1.0": 9
            },
            "country": {
                "Finland": 9
            },
            "organisationName": {},
            "sourceSystemId": {
                "20.5000.1025/5N1-FST-J0E": 9
            },
            "typeStatus": {},
            "datasetId": {},
            "hasMedia": {
                "false": 5,
                "true": 4
            }
        }
    },
    "links": {
        "self": "https://sandbox.dissco.tech/api/v1/specimens/aggregation?country=Finland&sourceSystemId=20.5000.1025/5N1-FST-J0E"
    }
}
```

User story:
https://naturalis.atlassian.net/browse/DD-395