### PR TITLE
Add topicDiscipline, add hdl url and add totalHits searches

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/SpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/SpecimenController.java
@@ -14,7 +14,6 @@ import eu.dissco.backend.exceptions.UnprocessableEntityException;
 import eu.dissco.backend.service.SpecimenService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -37,6 +36,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class SpecimenController {
 
   private final SpecimenService service;
+
+  private static String getPath(HttpServletRequest request) {
+    var path = SANDBOX_URI + request.getRequestURI();
+    var queryString = request.getQueryString();
+    if (queryString != null) {
+      return path + "?" + request.getQueryString();
+    }
+    return path;
+  }
 
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -158,9 +166,17 @@ public class SpecimenController {
       @RequestParam MultiValueMap<String, String> params, HttpServletRequest request)
       throws IOException, UnknownParameterException {
     log.info("Request for aggregations");
-    var path = SANDBOX_URI + request.getRequestURI() + "?" + Objects.requireNonNullElse(
-        request.getQueryString(), "");
+    String path = getPath(request);
     var aggregations = service.aggregations(params, path);
+    return ResponseEntity.ok(aggregations);
+  }
+
+  @ResponseStatus(HttpStatus.OK)
+  @GetMapping(value = "discipline", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonApiWrapper> discipline(HttpServletRequest request) throws IOException {
+    log.info("Request for aggregations");
+    var path = SANDBOX_URI + request.getRequestURI();
+    var aggregations = service.discipline(path);
     return ResponseEntity.ok(aggregations);
   }
 }

--- a/src/main/java/eu/dissco/backend/controller/UserController.java
+++ b/src/main/java/eu/dissco/backend/controller/UserController.java
@@ -48,11 +48,11 @@ public class UserController {
       throws JsonProcessingException, ConflictException, ForbiddenException {
     var tokenId = getNameFromToken(authentication);
     log.info("User: {} has requested to update user information of: {}", tokenId,
-        request.data().getId());
-    checkAuthorisation(tokenId, request.data().getId());
+        request.getData().getId());
+    checkAuthorisation(tokenId, request.getData().getId());
     var response = service.createNewUser(request);
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(new JsonApiWrapper(response, new JsonApiLinks(SELF_LINK + request.data().getId())));
+        .body(new JsonApiWrapper(response, new JsonApiLinks(SELF_LINK + request.getData().getId())));
   }
 
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/eu/dissco/backend/domain/MappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/MappingTerms.java
@@ -30,6 +30,7 @@ public enum MappingTerms {
   BASIS_OF_RECORD("basisOfRecord", "digitalSpecimen.ods:attributes.dwc:basisOfRecord.keyword"),
   LIVING_OR_PRESERVED("livingOrPreserved",
       "digitalSpecimen.ods:attributes.ods:livingOrPreserved.keyword"),
+  TOPIC_DISCIPLINE("topicDiscipline", "digitalSpecimen.ods:attributes.ods:topicDiscipline.keyword"),
   QUERY("q", "q");
 
   public static final Set<MappingTerms> aggregationList = getAggregationList();
@@ -66,6 +67,7 @@ public enum MappingTerms {
     aggregationTerms.add(PHYLUM);
     aggregationTerms.add(BASIS_OF_RECORD);
     aggregationTerms.add(LIVING_OR_PRESERVED);
+    aggregationTerms.add(TOPIC_DISCIPLINE);
     return aggregationTerms;
   }
 
@@ -91,6 +93,7 @@ public enum MappingTerms {
     paramMap.put(PHYLUM.name, PHYLUM.fullName);
     paramMap.put(BASIS_OF_RECORD.name, BASIS_OF_RECORD.fullName);
     paramMap.put(LIVING_OR_PRESERVED.name, LIVING_OR_PRESERVED.fullName);
+    paramMap.put(TOPIC_DISCIPLINE.name, TOPIC_DISCIPLINE.fullName);
     paramMap.put(QUERY.name, QUERY.fullName);
     return paramMap;
   }

--- a/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiListResponseWrapper.java
+++ b/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiListResponseWrapper.java
@@ -7,16 +7,25 @@ import lombok.Value;
 public class JsonApiListResponseWrapper {
   List<JsonApiData> data;
   JsonApiLinksFull links;
+  JsonApiMeta meta;
 
   public JsonApiListResponseWrapper(List<JsonApiData> dataNode, JsonApiLinksFull linksNode){
     this.data = dataNode;
     this.links = linksNode;
+    this.meta = null;
+  }
+
+  public JsonApiListResponseWrapper(List<JsonApiData> dataNode, JsonApiLinksFull linksNode, JsonApiMeta metadata){
+    this.data = dataNode;
+    this.links = linksNode;
+    this.meta = metadata;
   }
 
   public JsonApiListResponseWrapper(List<JsonApiData> domainObjectPlusOne,  int pageNumber, int pageSize, String path) {
     boolean hasNextPage = domainObjectPlusOne.size() > pageSize;
     this.data = hasNextPage ? domainObjectPlusOne.subList(0, pageSize) : domainObjectPlusOne;
     this.links = new JsonApiLinksFull(pageNumber, pageSize, hasNextPage, path);
+    this.meta = null;
   }
 
 }

--- a/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiMeta.java
+++ b/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiMeta.java
@@ -1,0 +1,3 @@
+package eu.dissco.backend.domain.jsonapi;
+
+public record JsonApiMeta(long totalRecords) { }

--- a/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiWrapper.java
+++ b/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiWrapper.java
@@ -1,5 +1,22 @@
 package eu.dissco.backend.domain.jsonapi;
 
-public record JsonApiWrapper(JsonApiData data, JsonApiLinks links) {
+import lombok.Value;
 
+@Value
+public class JsonApiWrapper {
+  JsonApiData data;
+  JsonApiLinks links;
+  JsonApiMeta meta;
+
+  public JsonApiWrapper(JsonApiData data, JsonApiLinks links) {
+    this.data = data;
+    this.links = links;
+    this.meta = null;
+  }
+
+  public JsonApiWrapper(JsonApiData data, JsonApiLinks links, JsonApiMeta meta) {
+    this.data = data;
+    this.links = links;
+    this.meta = meta;
+  }
 }

--- a/src/main/java/eu/dissco/backend/repository/DigitalMediaObjectRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/DigitalMediaObjectRepository.java
@@ -2,6 +2,7 @@ package eu.dissco.backend.repository;
 
 import static eu.dissco.backend.database.jooq.Tables.NEW_DIGITAL_MEDIA_OBJECT;
 import static eu.dissco.backend.database.jooq.Tables.NEW_DIGITAL_SPECIMEN;
+import static eu.dissco.backend.repository.RepositoryUtils.HANDLE_STRING;
 import static eu.dissco.backend.repository.RepositoryUtils.getOffset;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -58,14 +59,15 @@ public class DigitalMediaObjectRepository {
 
   private DigitalMediaObject mapToMultiMediaObject(Record dbRecord) {
     try {
-      return new DigitalMediaObject(dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.ID),
+      return new DigitalMediaObject(
+          HANDLE_STRING + dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.ID),
           dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.VERSION),
           dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.CREATED),
           dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.TYPE),
-          dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.DIGITAL_SPECIMEN_ID),
+          HANDLE_STRING + dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.DIGITAL_SPECIMEN_ID),
           dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.MEDIA_URL),
           dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.FORMAT),
-          dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.SOURCE_SYSTEM_ID),
+          HANDLE_STRING + dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.SOURCE_SYSTEM_ID),
           mapper.readTree(dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.DATA).data()),
           mapper.readTree(dbRecord.get(NEW_DIGITAL_MEDIA_OBJECT.ORIGINAL_DATA).data()));
     } catch (JsonProcessingException e) {

--- a/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
@@ -1,6 +1,8 @@
 package eu.dissco.backend.repository;
 
 import static eu.dissco.backend.domain.MappingTerms.aggregationList;
+import static eu.dissco.backend.repository.RepositoryUtils.HANDLE_STRING;
+import static eu.dissco.backend.repository.RepositoryUtils.addUrlToAttributes;
 import static eu.dissco.backend.repository.RepositoryUtils.getOffset;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -19,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.backend.domain.AnnotationResponse;
 import eu.dissco.backend.domain.DigitalSpecimen;
+import eu.dissco.backend.domain.MappingTerms;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -29,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -84,18 +88,28 @@ public class ElasticSearchRepository {
     var annotation = json.get("annotation");
     var createdOn = parseDate(annotation.get(FIELD_CREATED));
     var generatedOn = parseDate(annotation.get(FIELD_GENERATED));
-    return new AnnotationResponse(json.get("id").asText(), json.get("version").asInt(),
-        getText(annotation, "type"), getText(annotation, "motivation"), annotation.get("target"),
-        annotation.get("body"), annotation.get("preferenceScore").asInt(),
-        getText(annotation, "creator"), createdOn, annotation.get("generator"), generatedOn, null);
+    return new AnnotationResponse(
+        HANDLE_STRING + json.get("id").asText(),
+        json.get("version").asInt(),
+        getText(annotation, "type"),
+        getText(annotation, "motivation"),
+        annotation.get("target"),
+        annotation.get("body"),
+        annotation.get("preferenceScore").asInt(),
+        getText(annotation, "creator"),
+        createdOn,
+        annotation.get("generator"),
+        generatedOn,
+        null);
   }
 
   private DigitalSpecimen mapToDigitalSpecimen(ObjectNode json) {
     var digitalSpecimen = json.get("digitalSpecimen");
     var attributes = digitalSpecimen.get("ods:attributes");
+    addUrlToAttributes(attributes);
     var createdOn = parseDate(json.get(FIELD_CREATED));
     return new DigitalSpecimen(
-        json.get("id").asText(),
+        HANDLE_STRING + json.get("id").asText(),
         json.get("midsLevel").asInt(),
         json.get("version").asInt(),
         createdOn,
@@ -131,7 +145,7 @@ public class ElasticSearchRepository {
     }
   }
 
-  public List<DigitalSpecimen> search(Map<String, List<String>> params, int pageNumber,
+  public Pair<Long, List<DigitalSpecimen>> search(Map<String, List<String>> params, int pageNumber,
       int pageSize)
       throws IOException {
     var offset = getOffset(pageNumber, pageSize);
@@ -139,13 +153,18 @@ public class ElasticSearchRepository {
     var searchRequest = new SearchRequest.Builder().index(DIGITAL_SPECIMEN_INDEX)
         .query(
             q -> q.bool(b -> b.should(queries).minimumShouldMatch(String.valueOf(params.size()))))
+        .trackTotalHits(t -> t.enabled(Boolean.TRUE))
         .from(offset)
         .size(pageSize).build();
-    return client.search(searchRequest, ObjectNode.class).hits().hits().stream().map(Hit::source)
+    var searchResult = client.search(searchRequest, ObjectNode.class);
+    var totalHits = searchResult.hits().total().value();
+    var specimens = searchResult.hits().hits().stream().map(Hit::source)
         .map(this::mapToDigitalSpecimen).toList();
+    return Pair.of(totalHits, specimens);
   }
 
-  public Map<String, Map<String, Long>> getAggregations(Map<String, List<String>> params) throws IOException {
+  public Map<String, Map<String, Long>> getAggregations(Map<String, List<String>> params)
+      throws IOException {
     var aggregationQueries = new HashMap<String, Aggregation>();
     var queries = generateQueries(params);
     for (var aggregationTerm : aggregationList) {
@@ -177,5 +196,18 @@ public class ElasticSearchRepository {
       mapped.put(entry.getKey(), aggregation);
     }
     return mapped;
+  }
+
+  public Pair<Long, Map<String, Map<String, Long>>> getAggregation(MappingTerms mappingTerm)
+      throws IOException {
+    var aggregationRequest = new SearchRequest.Builder().index(DIGITAL_SPECIMEN_INDEX)
+        .trackTotalHits(t -> t.enabled(Boolean.TRUE))
+        .aggregations(mappingTerm.getName(),
+            AggregationBuilders.terms().field(mappingTerm.getFullName()).build()._toAggregation())
+        .build();
+    var aggregation = client.search(aggregationRequest, ObjectNode.class);
+    var totalRecords = aggregation.hits().total().value();
+    var aggregationResult = collectResult(aggregation.aggregations());
+    return Pair.of(totalRecords, aggregationResult);
   }
 }

--- a/src/main/java/eu/dissco/backend/repository/RepositoryUtils.java
+++ b/src/main/java/eu/dissco/backend/repository/RepositoryUtils.java
@@ -1,9 +1,19 @@
 package eu.dissco.backend.repository;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public class RepositoryUtils {
+
+  public static final String HANDLE_STRING = "https://hdl.handle.net/";
 
   private RepositoryUtils() {
     // Utility class
+  }
+
+  public static void addUrlToAttributes(JsonNode attributes){
+    ((ObjectNode) attributes).put("ods:sourceSystemId",
+        HANDLE_STRING + attributes.get("ods:sourceSystemId").asText());
   }
 
   protected static int getOffset(int pageNumber, int pageSize) {

--- a/src/main/java/eu/dissco/backend/repository/SpecimenRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/SpecimenRepository.java
@@ -1,9 +1,12 @@
 package eu.dissco.backend.repository;
 
 import static eu.dissco.backend.database.jooq.Tables.NEW_DIGITAL_SPECIMEN;
+import static eu.dissco.backend.repository.RepositoryUtils.HANDLE_STRING;
+import static eu.dissco.backend.repository.RepositoryUtils.addUrlToAttributes;
 import static eu.dissco.backend.repository.RepositoryUtils.getOffset;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.domain.DigitalSpecimen;
 import java.util.List;
@@ -40,7 +43,7 @@ public class SpecimenRepository {
   private DigitalSpecimen mapToDigitalSpecimen(Record dbRecord) {
     try {
       return new DigitalSpecimen(
-          dbRecord.get(NEW_DIGITAL_SPECIMEN.ID),
+          HANDLE_STRING + dbRecord.get(NEW_DIGITAL_SPECIMEN.ID),
           dbRecord.get(NEW_DIGITAL_SPECIMEN.MIDSLEVEL),
           dbRecord.get(NEW_DIGITAL_SPECIMEN.VERSION),
           dbRecord.get(NEW_DIGITAL_SPECIMEN.CREATED),
@@ -51,13 +54,19 @@ public class SpecimenRepository {
           dbRecord.get(NEW_DIGITAL_SPECIMEN.ORGANIZATION_ID),
           dbRecord.get(NEW_DIGITAL_SPECIMEN.DATASET),
           dbRecord.get(NEW_DIGITAL_SPECIMEN.PHYSICAL_SPECIMEN_COLLECTION),
-          dbRecord.get(NEW_DIGITAL_SPECIMEN.SOURCE_SYSTEM_ID),
-          mapper.readTree(dbRecord.get(NEW_DIGITAL_SPECIMEN.DATA).data()),
+          HANDLE_STRING + dbRecord.get(NEW_DIGITAL_SPECIMEN.SOURCE_SYSTEM_ID),
+          getData(dbRecord),
           mapper.readTree(dbRecord.get(NEW_DIGITAL_SPECIMEN.ORIGINAL_DATA).data()),
           dbRecord.get(NEW_DIGITAL_SPECIMEN.DWCA_ID));
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private JsonNode getData(Record dbRecord) throws JsonProcessingException {
+    var attributes = mapper.readTree(dbRecord.get(NEW_DIGITAL_SPECIMEN.DATA).data());
+    addUrlToAttributes(attributes);
+    return attributes;
   }
 
 }

--- a/src/main/java/eu/dissco/backend/service/UserService.java
+++ b/src/main/java/eu/dissco/backend/service/UserService.java
@@ -28,8 +28,8 @@ public class UserService {
   public JsonApiData createNewUser(JsonApiWrapper request)
       throws JsonProcessingException, ConflictException {
     checkType(request);
-    var requestUser = mapper.treeToValue(request.data().getAttributes(), User.class);
-    var id = request.data().getId();
+    var requestUser = mapper.treeToValue(request.getData().getAttributes(), User.class);
+    var id = request.getData().getId();
     var optionalUser = repository.find(id);
     if (optionalUser.isEmpty()) {
       var userResponse = repository.createNewUser(id, requestUser);
@@ -41,8 +41,8 @@ public class UserService {
   }
 
   private void checkType(JsonApiWrapper request) throws InvalidTypeException {
-    if (!TYPE.equals(request.data().getType())) {
-      log.warn("Type: {} is not relevant for users endpoint", request.data().getType());
+    if (!TYPE.equals(request.getData().getType())) {
+      log.warn("Type: {} is not relevant for users endpoint", request.getData().getType());
       throw new InvalidTypeException();
     }
   }
@@ -59,17 +59,17 @@ public class UserService {
   public JsonApiData updateUser(String id, JsonApiWrapper request)
       throws ConflictException, NotFoundException {
     checkType(request);
-    if (id.equals(request.data().getId())) {
+    if (id.equals(request.getData().getId())) {
       var optionalUser = repository.find(id);
       if (optionalUser.isPresent()) {
-        var user = repository.updateUser(id, request.data().getAttributes());
+        var user = repository.updateUser(id, request.getData().getAttributes());
         return new JsonApiData(id, TYPE, mapper.valueToTree(user));
       } else {
         log.warn("No user with id: {} is present in the database", id);
         throw new NotFoundException();
       }
     } else {
-      log.warn("ID: {} is equal to id in request: {}", id, request.data().getType());
+      log.warn("ID: {} is equal to id in request: {}", id, request.getData().getType());
       throw new InvalidIdException();
     }
   }

--- a/src/test/java/eu/dissco/backend/TestUtils.java
+++ b/src/test/java/eu/dissco/backend/TestUtils.java
@@ -23,6 +23,7 @@ public class TestUtils {
   public static final String TYPE = "users";
   public static final String FORBIDDEN_MESSAGE =
       "User: " + USER_ID_TOKEN + " is not allowed to perform this action";
+  public static final String HANDLE = "https://hdl.handle.net/";
   public static final String PREFIX = "20.5000.1025";
   public static final String SUFFIX = "ABC-123-XYZ";
   public static final String ID = PREFIX + "/" + SUFFIX;
@@ -96,6 +97,11 @@ public class TestUtils {
   public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId)
       throws JsonProcessingException {
     return givenDigitalSpecimen(id, physicalId, 1, SOURCE_SYSTEM_ID_1);
+  }
+
+  public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId, String sourceSystem)
+      throws JsonProcessingException {
+    return givenDigitalSpecimen(id, physicalId, 1, sourceSystem);
   }
 
   public static DigitalSpecimen givenDigitalSpecimen(String id, String physicalId, int version,

--- a/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
@@ -152,7 +152,21 @@ class SpecimenControllerTest {
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(((JsonApiWrapper) result.getBody()).data()).isEqualTo(data);
+    assertThat(((JsonApiWrapper) result.getBody()).getData()).isEqualTo(data);
+  }
+
+  @Test
+  void testDiscipline() throws Exception {
+    //Given
+    var data = new JsonApiData("id", "aggregations", MAPPER.valueToTree(givenAggregationMap()));
+    given(service.discipline(anyString())).willReturn(new JsonApiWrapper(data, new JsonApiLinks("test")));
+
+    // When
+    var result = controller.discipline(mockRequest);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat((result.getBody()).getData()).isEqualTo(data);
   }
 
 }

--- a/src/test/java/eu/dissco/backend/repository/SpecimenRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/SpecimenRepositoryIT.java
@@ -1,7 +1,10 @@
 package eu.dissco.backend.repository;
 
+import static eu.dissco.backend.TestUtils.HANDLE;
 import static eu.dissco.backend.TestUtils.MAPPER;
+import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_1;
 import static eu.dissco.backend.TestUtils.givenDigitalSpecimen;
+import static eu.dissco.backend.TestUtils.givenDigitalSpecimenSourceSystem;
 import static eu.dissco.backend.database.jooq.Tables.NEW_DIGITAL_SPECIMEN;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,7 +53,7 @@ class SpecimenRepositoryIT extends BaseRepositoryIT {
     var result = repository.getLatestSpecimenById("20.5000.1025/ABC-123-XY3");
 
     // Then
-    assertThat(result).isEqualTo(givenDigitalSpecimen("20.5000.1025/ABC-123-XY3"));
+    assertThat(result).isEqualTo(givenDigitalSpecimenSourceSystem(HANDLE + "20.5000.1025/ABC-123-XY3", HANDLE + SOURCE_SYSTEM_ID_1));
   }
 
   private void populateSpecimenTable() throws JsonProcessingException {

--- a/src/test/java/eu/dissco/backend/utils/DigitalMediaObjectUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/DigitalMediaObjectUtils.java
@@ -3,6 +3,7 @@ package eu.dissco.backend.utils;
 import static eu.dissco.backend.TestUtils.CREATED;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.SANDBOX_URI;
+import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_1;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -28,8 +29,21 @@ public class DigitalMediaObjectUtils {
   }
 
   public static DigitalMediaObject givenDigitalMediaObject(String mediaId, String specimenId) {
-    return new DigitalMediaObject(mediaId, 1, CREATED, "2DImageObject", specimenId,
-        "https://dissco.com", "image/jpeg", "20.5000.1025/GW0-TYL-YRU",
+    return givenDigitalMediaObject(mediaId, specimenId, SOURCE_SYSTEM_ID_1, 1);
+  }
+
+  public static DigitalMediaObject givenDigitalMediaObject(String mediaId, String specimenId, int version) {
+    return givenDigitalMediaObject(mediaId, specimenId, SOURCE_SYSTEM_ID_1, version);
+  }
+  public static DigitalMediaObject givenDigitalMediaObject(String mediaId, String specimenId,
+      String sourceSystemId){
+    return givenDigitalMediaObject(mediaId, specimenId, sourceSystemId, 1);
+  }
+
+  public static DigitalMediaObject givenDigitalMediaObject(String mediaId, String specimenId,
+      String sourceSystemId, int version) {
+    return new DigitalMediaObject(mediaId, version, CREATED, "2DImageObject", specimenId,
+        "https://dissco.com", "image/jpeg", sourceSystemId,
         givenDigitalMediaObjectData(), givenDigitalMediaObjectOriginalData());
   }
 


### PR DESCRIPTION
Couple of small changes for the frontend.
Add topicDiscipline with /discipline endpoint for the DiSSCover homepage.
Add https://hdl.handle.net/ in front of handles to make them resolvable.
Add totalHits on search queries to display in frontend

https://naturalis.atlassian.net/browse/DD-488
https://naturalis.atlassian.net/browse/DD-490
https://naturalis.atlassian.net/browse/DD-492