### PR TITLE
Create endpoint for searching within term

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -3,7 +3,6 @@ package eu.dissco.backend.controller;
 import static eu.dissco.backend.controller.ControllerUtils.DEFAULT_PAGE_NUM;
 import static eu.dissco.backend.controller.ControllerUtils.DEFAULT_PAGE_SIZE;
 import static eu.dissco.backend.controller.ControllerUtils.SANDBOX_URI;
-import jakarta.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +13,7 @@ import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.backend.exceptions.NoAnnotationFoundException;
 import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.service.AnnotationService;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/eu/dissco/backend/controller/SpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/SpecimenController.java
@@ -102,7 +102,8 @@ public class SpecimenController {
 
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/{prefix}/{suffix}/{version}/full", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonApiWrapper> getSpecimenByVersionFull(@PathVariable("prefix") String prefix,
+  public ResponseEntity<JsonApiWrapper> getSpecimenByVersionFull(
+      @PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, @PathVariable("version") int version,
       HttpServletRequest request) throws NotFoundException, JsonProcessingException {
     var id = prefix + '/' + suffix;
@@ -189,6 +190,17 @@ public class SpecimenController {
     var path = SANDBOX_URI + request.getRequestURI();
     var aggregations = service.discipline(path);
     return ResponseEntity.ok(aggregations);
+  }
+
+  @ResponseStatus(HttpStatus.OK)
+  @GetMapping(value = "searchTermValue", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonApiWrapper> searchTermValue(
+      @RequestParam String term, @RequestParam String value, HttpServletRequest request)
+      throws IOException, UnknownParameterException {
+    log.info("Request text search for term value of term: {} with value: {}", term, value);
+    String path = getPath(request);
+    var result = service.searchTermValue(term, value, path);
+    return ResponseEntity.ok(result);
   }
 }
 

--- a/src/main/java/eu/dissco/backend/domain/MappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/MappingTerms.java
@@ -73,7 +73,7 @@ public enum MappingTerms {
 
   private static Map<String, String> getParamMapping() {
     var paramMap = new HashMap<String, String>();
-    paramMap.put(TYPE.getName(), TYPE.getFullName());
+    paramMap.put(TYPE.name, TYPE.fullName);
     paramMap.put(COUNTRY.name, COUNTRY.fullName);
     paramMap.put(COUNTRY_CODE.name, COUNTRY_CODE.fullName);
     paramMap.put(MIDS_LEVEL.name, MIDS_LEVEL.fullName);

--- a/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
@@ -204,10 +204,21 @@ public class ElasticSearchRepository {
         .trackTotalHits(t -> t.enabled(Boolean.TRUE))
         .aggregations(mappingTerm.getName(),
             AggregationBuilders.terms().field(mappingTerm.getFullName()).build()._toAggregation())
+        .size(0)
         .build();
     var aggregation = client.search(aggregationRequest, ObjectNode.class);
     var totalRecords = aggregation.hits().total().value();
     var aggregationResult = collectResult(aggregation.aggregations());
     return Pair.of(totalRecords, aggregationResult);
+  }
+
+  public Map<String, Map<String, Long>> searchTermValue(String name, String field, String value) throws IOException {
+    var searchQuery = new SearchRequest.Builder().index(DIGITAL_SPECIMEN_INDEX)
+        .query( q -> q.prefix( m -> m.field(field).value(value)))
+        .aggregations(name, agg -> agg.terms(t -> t.field(field)))
+        .size(0)
+        .build();
+    var aggregation = client.search(searchQuery, ObjectNode.class);
+    return collectResult(aggregation.aggregations());
   }
 }

--- a/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
@@ -178,4 +178,18 @@ class SpecimenControllerTest {
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
+  @Test
+  void testSearchTermValue() throws Exception {
+    //Given
+    var data = new JsonApiData("id", "aggregations", MAPPER.valueToTree(givenAggregationMap()));
+    given(service.searchTermValue(anyString(), anyString(), anyString())).willReturn(new JsonApiWrapper(data, new JsonApiLinks("test")));
+
+    // When
+    var result = controller.searchTermValue("sourceSystem", "20.500", mockRequest);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat((result.getBody()).getData()).isEqualTo(data);
+  }
+
 }

--- a/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
@@ -451,7 +451,7 @@ class SpecimenServiceTest {
   }
 
   @Test
-  void testSearchTerm() throws IOException, UnknownParameterException {
+  void testSearchTermValue() throws IOException, UnknownParameterException {
     // Given
     var aggregation = Map.of("topicDiscipline", Map.of("Zoology", 349555L));
     given(elasticRepository.searchTermValue(TOPIC_DISCIPLINE.getName(),
@@ -468,6 +468,12 @@ class SpecimenServiceTest {
     assertThat(result).isEqualTo(expected);
   }
 
+  @Test
+  void testSearchTermUnknown(){
+    // When / Then
+    assertThatThrownBy(() -> service.searchTermValue("unknownTerm", "Z", SPECIMEN_PATH)).isInstanceOf(
+        UnknownParameterException.class);
+  }
 
   private String givenJsonLDString() {
     return """


### PR DESCRIPTION
Endpoint where we can de prefix searches for term.
So when you put in the term and the search value it will check all aggregated values for that term.
For example you have Spain, Final and sans origin for term Country.
If you put in country and S as value it will return Spain and sand origin with their respective values.
If you put in country and Sp it will only return Spain.

Add hits = 0 as it only needs to return the buckets, not the search results, is probably quicker.

https://naturalis.atlassian.net/browse/DD-491