### PR TITLE
add count in meta field

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,10 +1,15 @@
 # Date: June 16, 2023
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
 # Solution: Spring needs to update its version of kafka
-CVE-2023-34455
+# CVE-2023-34455
 
 # Date: August 24, 2023
 # Issue: snappy-java used by kafka, which is used by spring-kafka
 # Solution: Spring needs to update its version of kafka
-CVE-2023-34453
-CVE-2023-34454
+# CVE-2023-34453
+# CVE-2023-34454
+
+# Date: August 25
+# Manually set kafka version to 3.5.1. This version addresses the above CVEs
+# Should remove this property once spring-kafka updates
+

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,3 +2,9 @@
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
 # Solution: Spring needs to update its version
 CVE-2023-34455
+
+# Date: August 24, 2023
+# Issue: snappy-java used by kafka, which is used by spring-kafka
+# Solution: Spring needs to update its version
+CVE-2023-34453
+CVE-2023-34454

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,10 +1,10 @@
 # Date: June 16, 2023
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
 # Solution: Spring needs to update its version
-CVE-2023-34455
+#CVE-2023-34455
 
 # Date: August 24, 2023
 # Issue: snappy-java used by kafka, which is used by spring-kafka
 # Solution: Spring needs to update its version
-CVE-2023-34453
-CVE-2023-34454
+#CVE-2023-34453
+#CVE-2023-34454

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,10 +1,10 @@
 # Date: June 16, 2023
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
-# Solution: Spring needs to update its version
-#CVE-2023-34455
+# Solution: Spring needs to update its version of kafka
+CVE-2023-34455
 
 # Date: August 24, 2023
 # Issue: snappy-java used by kafka, which is used by spring-kafka
-# Solution: Spring needs to update its version
-#CVE-2023-34453
-#CVE-2023-34454
+# Solution: Spring needs to update its version of kafka
+CVE-2023-34453
+CVE-2023-34454

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <spring-cloud-starter-openfeign.version>4.0.2</spring-cloud-starter-openfeign.version>
     <feign-okhttp.version>12.3</feign-okhttp.version>
     <springdoc.version>2.1.0</springdoc.version>
+    <kafka.version>3.5.1</kafka.version>
     <mongodb-driver.version>3.12.13</mongodb-driver.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -135,7 +135,7 @@ public class AnnotationController {
   public ResponseEntity<JsonApiListResponseWrapper> getAnnotationsForUser(
       @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
       @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize, HttpServletRequest request,
-      Authentication authentication) {
+      Authentication authentication)throws IOException {
     var userId = getNameFromToken(authentication);
     log.info("Received get request to show all annotations for user: {}", userId);
     String path = SANDBOX_URI + request.getRequestURI();

--- a/src/main/java/eu/dissco/backend/controller/SpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/SpecimenController.java
@@ -57,7 +57,7 @@ public class SpecimenController {
   @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> getSpecimen(
       @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
-      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize, HttpServletRequest request) {
+      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize, HttpServletRequest request) throws IOException {
     log.info("Received get request for specimen");
     var path = SANDBOX_URI + request.getRequestURI();
     var specimen = service.getSpecimen(pageNumber, pageSize, path);

--- a/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiListResponseWrapper.java
+++ b/src/main/java/eu/dissco/backend/domain/jsonapi/JsonApiListResponseWrapper.java
@@ -31,4 +31,12 @@ public class JsonApiListResponseWrapper {
     this.meta = null;
   }
 
+  public JsonApiListResponseWrapper(List<JsonApiData> domainObjectPlusOne, int pageNumber,
+      int pageSize, String path, JsonApiMeta meta) {
+    boolean hasNextPage = domainObjectPlusOne.size() > pageSize;
+    this.data = hasNextPage ? domainObjectPlusOne.subList(0, pageSize) : domainObjectPlusOne;
+    this.links = new JsonApiLinksFull(pageNumber, pageSize, hasNextPage, path);
+    this.meta = meta;
+  }
+
 }

--- a/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
@@ -47,17 +47,6 @@ public class AnnotationRepository {
         .fetch().size();
   }
 
-  public List<AnnotationResponse> getAnnotationsForUser(String userId, int pageNumber,
-      int pageSize) {
-    int offset = getOffset(pageNumber, pageSize);
-    var pageSizePlusOne = pageSize + ONE_TO_CHECK_NEXT;
-    return context.select(NEW_ANNOTATION.asterisk())
-        .from(NEW_ANNOTATION)
-        .where(NEW_ANNOTATION.CREATOR.eq(userId))
-        .orderBy(NEW_ANNOTATION.CREATED)
-        .limit(pageSizePlusOne).offset(offset).fetch(this::mapToAnnotation);
-  }
-
   public List<AnnotationResponse> getForTarget(String id) {
     return context.select(NEW_ANNOTATION.asterisk())
         .from(NEW_ANNOTATION)

--- a/src/main/java/eu/dissco/backend/repository/SpecimenRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/SpecimenRepository.java
@@ -2,15 +2,12 @@ package eu.dissco.backend.repository;
 
 import static eu.dissco.backend.database.jooq.Tables.NEW_DIGITAL_SPECIMEN;
 import static eu.dissco.backend.repository.RepositoryUtils.HANDLE_STRING;
-import static eu.dissco.backend.repository.RepositoryUtils.ONE_TO_CHECK_NEXT;
 import static eu.dissco.backend.repository.RepositoryUtils.addUrlToAttributes;
-import static eu.dissco.backend.repository.RepositoryUtils.getOffset;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.domain.DigitalSpecimen;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -24,16 +21,6 @@ public class SpecimenRepository {
 
   private final DSLContext context;
   private final ObjectMapper mapper;
-
-  public List<DigitalSpecimen> getSpecimensLatest(int pageNumber, int pageSize) {
-    int offset = getOffset(pageNumber, pageSize);
-    var pageSizePlusOne = pageSize + ONE_TO_CHECK_NEXT;
-    return context.select(NEW_DIGITAL_SPECIMEN.asterisk())
-        .from(NEW_DIGITAL_SPECIMEN)
-        .offset(offset)
-        .limit(pageSizePlusOne)
-        .fetch(this::mapToDigitalSpecimen);
-  }
 
   public DigitalSpecimen getLatestSpecimenById(String id) {
     return context.select(NEW_DIGITAL_SPECIMEN.asterisk())

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -152,7 +152,7 @@ class AnnotationControllerTest {
   }
 
   @Test
-  void testGetAnnotationsForUserJsonResponse() {
+  void testGetAnnotationsForUserJsonResponse() throws Exception {
     // Given
     givenAuthentication(USER_ID_TOKEN);
 

--- a/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
@@ -54,7 +54,7 @@ class SpecimenControllerTest {
   }
 
   @Test
-  void testGetSpecimen() {
+  void testGetSpecimen() throws Exception{
     // When
     var result = controller.getSpecimen(1, 1, mockRequest);
 

--- a/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
@@ -87,56 +87,6 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetAnnotationsForUser() {
-    // Given
-    String userId = USER_ID_TOKEN;
-    int pageNumber = 1;
-    int pageSize = 11;
-    List<AnnotationResponse> annotationsNonTarget = List.of(
-        givenAnnotationResponse("test", "test"));
-    postAnnotations(annotationsNonTarget);
-
-    List<String> annotationIds = IntStream.rangeClosed(0, pageSize - 1).boxed()
-        .map(Object::toString).toList();
-    List<AnnotationResponse> expectedResponse = new ArrayList<>();
-
-    for (String id : annotationIds) {
-      expectedResponse.add(givenAnnotationResponse(userId, id));
-    }
-    postAnnotations(expectedResponse);
-
-    // When
-    var receivedResponse = repository.getAnnotationsForUser(userId, pageNumber, pageSize);
-
-    // Then
-    assertThat(receivedResponse).hasSameElementsAs(expectedResponse);
-  }
-
-  @Test
-  void testGetAnnotationsForUserSecondPage() {
-    // Given
-    String userId = USER_ID_TOKEN;
-    int pageNumber = 2;
-    int pageSize = 11;
-    List<AnnotationResponse> annotationsNonTarget = List.of(
-        givenAnnotationResponse("test", "test"));
-    postAnnotations(annotationsNonTarget);
-    List<String> annotationIds = IntStream.rangeClosed(0, (pageSize * 2) - 1).boxed()
-        .map(Object::toString).toList();
-    List<AnnotationResponse> annotations = new ArrayList<>();
-    for (String id : annotationIds) {
-      annotations.add(givenAnnotationResponse(userId, id));
-    }
-    postAnnotations(annotations);
-
-    // When
-    var receivedResponse = repository.getAnnotationsForUser(userId, pageNumber, pageSize);
-
-    // Then
-    assertThat(receivedResponse).hasSize(pageSize);
-  }
-
-  @Test
   void testGetForTarget() {
     // Given
     MAPPER.setSerializationInclusion(Include.ALWAYS);

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -374,6 +374,27 @@ class ElasticSearchRepositoryIT {
     assertThat(responseReceived.getRight()).isEqualTo(expected);
   }
 
+  @Test
+  void testGetAnnotationsForCreatorEmpty() throws IOException {
+    // Given
+    int pageNumber = 1;
+    int pageSize = 10;
+    var totalHits = 0L;
+    List<AnnotationResponse> givenAnnotations = new ArrayList<>();
+    for (long i = 0; i < 5; i++) {
+      String id = PREFIX + "/" + i;
+      givenAnnotations.add(givenAnnotationResponse(USER_ID_TOKEN, id));
+    }
+    postAnnotations(parseAnnotationToElasticFormat(givenAnnotations));
+
+    // When
+    var responseReceived = repository.getAnnotationsForCreator("a different user", pageNumber, pageSize);
+
+    // Then
+    assertThat(responseReceived.getLeft()).isZero();
+    assertThat(responseReceived.getRight()).isEmpty();
+  }
+
   private List<JsonNode> parseAnnotationToElasticFormat(List<AnnotationResponse> annotations) {
     return annotations.stream().map(this::annotationToElasticFormat).toList();
   }

--- a/src/test/java/eu/dissco/backend/repository/SpecimenRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/SpecimenRepositoryIT.java
@@ -31,20 +31,6 @@ class SpecimenRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetSpecimenLatest() throws JsonProcessingException {
-    // Given
-    populateSpecimenTable();
-
-    // When
-    var resultPage1 = repository.getSpecimensLatest(1, 15);
-    var resultPage2 = repository.getSpecimensLatest(2, 15);
-
-    // Then
-    assertThat(resultPage1).hasSize(16);
-    assertThat(resultPage2).hasSize(7);
-  }
-
-  @Test
   void testGetSpecimenById() throws JsonProcessingException {
     // Given
     populateSpecimenTable();

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -103,6 +103,29 @@ class AnnotationServiceTest {
   }
 
   @Test
+  void testGetAnnotationsForUserLastPage() throws Exception {
+    // Given
+    String userId = USER_ID_TOKEN;
+    String annotationId = "123";
+    int pageNumber = 2;
+    int pageSize = 15;
+    var totalCount = 30L;
+    String path = SANDBOX_URI + "api/v1/annotations/creator/json";
+    var tmp = givenAnnotationJsonResponse(path, pageNumber, pageSize,
+        userId, annotationId, false);
+    var expectedResponse = new JsonApiListResponseWrapper(tmp.getData(), tmp.getLinks(), new JsonApiMeta(totalCount));
+
+    given(elasticRepository.getAnnotationsForCreator(userId, pageNumber, pageSize))
+        .willReturn(Pair.of(totalCount,givenAnnotationResponseList(annotationId, pageSize)));
+
+    // When
+    var receivedResponse = service.getAnnotationsForUser(userId, pageNumber, pageSize, path);
+
+    // Then
+    assertThat(receivedResponse).isEqualTo(expectedResponse);
+  }
+
+  @Test
   void testGetAnnotationForTargetObject() {
     // Given
     var expected = List.of(givenAnnotationResponse());


### PR DESCRIPTION
Include total count of hits for specimens and annotations by a given creator. Value is stored in meta field. 


Jira: 

https://naturalis.atlassian.net/browse/DD-619?atlOrigin=eyJpIjoiYWE4NTc3NWU2NjI5NDFiYTg3MTI3ZDkyNGQ2ODk5NzAiLCJwIjoiaiJ9

https://naturalis.atlassian.net/browse/DD-620?atlOrigin=eyJpIjoiYjUxNDA1OGMxMmY1NGM5MDhjMjcxN2E1MDNhNjU1ODYiLCJwIjoiaiJ9