### PR TITLE
add annotation domain objects

### DIFF
--- a/src/main/java/eu/dissco/backend/domain/annotation/AggregateRating.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/AggregateRating.java
@@ -1,0 +1,36 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AggregateRating {
+
+  @JsonProperty("ods:type")
+  private String odsType;
+  @JsonProperty("schema.org:ratingCount")
+  private double ratingCount;
+  @JsonProperty("schema.org:ratingValue")
+  private double ratingValue;
+
+  public AggregateRating withOdsType(String odsType) {
+    this.odsType = odsType;
+    return this;
+  }
+
+  public AggregateRating withRatingCount(double ratingCount) {
+    this.ratingCount = ratingCount;
+    return this;
+  }
+
+  public AggregateRating ratingValue(double ratingValue) {
+    this.ratingValue = ratingValue;
+    return this;
+  }
+
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Annotation.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Annotation.java
@@ -1,0 +1,88 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Annotation {
+
+  @JsonProperty("ods:id")
+  private String odsId;
+  @JsonProperty("rdf:type")
+  private static final String RDF_TYPE = "Annotation";
+  @JsonProperty("oa:motivation")
+  private Motivation oaMotivation;
+  @JsonProperty("oa:motivatedBy")
+  private String oaMotivatedBy;
+  @JsonProperty("oa:target")
+  private Target oaTarget;
+  @JsonProperty("oa:body")
+  private Body oaBody;
+  @JsonProperty("oa:creator")
+  private Creator oaCreator;
+  @JsonProperty("dcterms:created")
+  private Date dcTermsCreated;
+  @JsonProperty("ods:deletedOn")
+  private Date odsDeletedOn;
+  @JsonProperty("as:generator")
+  private Generator asGenerator;
+  @JsonProperty("ods:aggregateRating")
+  private AggregateRating odsAggregateRating;
+
+  public Annotation withOdsId(String odsId) {
+    this.odsId = odsId;
+    return this;
+  }
+
+  public Annotation withOaMotivation(Motivation oaMotivation) {
+    this.oaMotivation = oaMotivation;
+    return this;
+  }
+
+  public Annotation withOaMotivatedBy(String oaMotivatedBy) {
+    this.oaMotivatedBy = oaMotivatedBy;
+    return this;
+  }
+
+  public Annotation withOaTarget(Target oaTarget) {
+    this.oaTarget = oaTarget;
+    return this;
+  }
+
+  public Annotation withOaBody(Body oaBody) {
+    this.oaBody = oaBody;
+    return this;
+  }
+
+  public Annotation withOaCreator(Creator oaCreator) {
+    this.oaCreator = oaCreator;
+    return this;
+  }
+
+  public Annotation withDcTermsCreated(Date dcTermsCreated) {
+    this.dcTermsCreated = dcTermsCreated;
+    return this;
+  }
+
+  public Annotation withOdsDeletedOn(Date odsDeletedOn) {
+    this.odsDeletedOn = odsDeletedOn;
+    return this;
+  }
+
+  public Annotation withAsGenerator(Generator asGenerator) {
+    this.asGenerator = asGenerator;
+    return this;
+  }
+
+  public Annotation withOdsAggregateRating(AggregateRating odsAggregateRating) {
+    this.odsAggregateRating = odsAggregateRating;
+    return this;
+  }
+
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Body.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Body.java
@@ -1,0 +1,43 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Body {
+
+  @JsonProperty("ods:type")
+  private String odsType;
+  @JsonProperty("oa:value")
+  private List<Object> oaValue;
+  @JsonProperty("dcterms:reference")
+  private String dcTermsReference;
+  @JsonProperty("ods:score")
+  private double odsScore;
+
+  public Body withOdsType(String odsType) {
+    this.odsType = odsType;
+    return this;
+  }
+
+  public Body withOaValue(List<Object> oaValue) {
+    this.oaValue = oaValue;
+    return this;
+  }
+
+  public Body withDcTermsReference(String dcTermsReference) {
+    this.dcTermsReference = dcTermsReference;
+    return this;
+  }
+
+  public Body withOdsScore(double odsScore) {
+    this.odsScore = odsScore;
+    return this;
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/ClassValueSelector.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/ClassValueSelector.java
@@ -1,0 +1,26 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ClassValueSelector extends Selector {
+
+  @JsonProperty("ods:class")
+  private String odsClass;
+
+  public ClassValueSelector() {
+    super(SelectorType.CLASS_VALUE_SELECTOR);
+  }
+
+  public ClassValueSelector(String odsClass) {
+    super(SelectorType.CLASS_VALUE_SELECTOR);
+    this.odsClass = odsClass;
+  }
+
+  public ClassValueSelector withOdsClass(String odsClass) {
+    this.odsClass = odsClass;
+    return this;
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Creator.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Creator.java
@@ -1,0 +1,35 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Creator {
+
+  @JsonProperty("ods:type")
+  private String odsType;
+  @JsonProperty("foaf:name")
+  private String foafName;
+  @JsonProperty("ods:id")
+  private String odsId;
+
+  public Creator withOdsType(String odsType) {
+    this.odsType = odsType;
+    return this;
+  }
+
+  public Creator withFoafName(String foafName) {
+    this.foafName = foafName;
+    return this;
+  }
+
+  public Creator withOdsId(String odsId) {
+    this.odsId = odsId;
+    return this;
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/FieldValueSelector.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/FieldValueSelector.java
@@ -1,0 +1,26 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+
+@Getter
+public class FieldValueSelector extends Selector {
+
+  @JsonProperty("ods:field")
+  private String odsField;
+
+  FieldValueSelector() {
+    super(SelectorType.FIELD_VALUE_SELECTOR);
+  }
+
+  FieldValueSelector(String odsField) {
+    super(SelectorType.FIELD_VALUE_SELECTOR);
+    this.odsField = odsField;
+  }
+
+  public FieldValueSelector withOdsField(String odsField) {
+    this.odsField = odsField;
+    return this;
+  }
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/FragmentSelector.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/FragmentSelector.java
@@ -1,0 +1,34 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class FragmentSelector extends Selector {
+
+  @JsonProperty("ac:hasRoi")
+  private HasRoi acHasRoi;
+  @JsonProperty("dcterms:conformsTo")
+  private String dctermsConformsTo;
+
+  public FragmentSelector() {
+    super(SelectorType.FRAGMENT_SELECTOR);
+  }
+
+  public FragmentSelector(HasRoi acHasRoi, String dctermsConformsTo) {
+    super(SelectorType.FRAGMENT_SELECTOR);
+    this.acHasRoi = acHasRoi;
+    this.dctermsConformsTo = dctermsConformsTo;
+  }
+
+  public FragmentSelector withAcHasRoi(HasRoi acHasRoi) {
+    this.acHasRoi = acHasRoi;
+    return this;
+  }
+
+  public FragmentSelector withDctermsConformsTo(String dctermsConformsTo) {
+    this.dctermsConformsTo = dctermsConformsTo;
+    return this;
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Generator.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Generator.java
@@ -1,0 +1,36 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Generator {
+
+  @JsonProperty("ods:type")
+  private String odsType;
+  @JsonProperty("foaf:name")
+  private String foafName;
+  @JsonProperty("ods:id")
+  private String odsId;
+
+  public Generator withOdsType(String odsType) {
+    this.odsType = odsType;
+    return this;
+  }
+
+  public Generator withFoafName(String foafName) {
+    this.foafName = foafName;
+    return this;
+  }
+
+  public Generator withOdsId(String odsId) {
+    this.odsId = odsId;
+    return this;
+  }
+
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/HasRoi.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/HasRoi.java
@@ -1,0 +1,42 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HasRoi {
+
+  @JsonProperty("ac:xFrac")
+  private double xFrac;
+  @JsonProperty("ac:yFrac")
+  private double yFrac;
+  @JsonProperty("ac:widthFrac")
+  private double widthFrac;
+  @JsonProperty("ac:HeightFrac")
+  private double heightFrac;
+
+  public HasRoi withAcxFrac(double xFrac) {
+    this.xFrac = xFrac;
+    return this;
+  }
+
+  public HasRoi withAcYFrac(double yFrac) {
+    this.yFrac = yFrac;
+    return this;
+  }
+
+  public HasRoi withAcWidthFrac(double widthFrac) {
+    this.widthFrac = widthFrac;
+    return this;
+  }
+
+  public HasRoi withAcHeightFrac(double heightFrac) {
+    this.heightFrac = heightFrac;
+    return this;
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Motivation.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Motivation.java
@@ -1,0 +1,12 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Motivation {
+
+  @JsonProperty("ods:adding") ADDING,
+  @JsonProperty("oa:assessing") ASSESSING,
+  @JsonProperty("oa:editing") EDITING,
+  @JsonProperty("oa:commenting") COMMENTING;
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Selector.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Selector.java
@@ -1,0 +1,14 @@
+package eu.dissco.backend.domain.annotation;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class Selector {
+
+  @JsonProperty("ods:type")
+  protected final SelectorType odsType;
+
+  protected Selector(SelectorType odsType) {
+    this.odsType = odsType;
+  }
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/SelectorType.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/SelectorType.java
@@ -1,0 +1,10 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SelectorType {
+  @JsonProperty("FieldValueSelector") FIELD_VALUE_SELECTOR,
+  @JsonProperty("ClassValueSelector") CLASS_VALUE_SELECTOR,
+  @JsonProperty("FragmentSelector") FRAGMENT_SELECTOR;
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Target.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Target.java
@@ -1,0 +1,37 @@
+package eu.dissco.backend.domain.annotation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@NoArgsConstructor
+@RequiredArgsConstructor
+@Getter
+public class Target {
+
+  @JsonProperty("ods:id")
+  private String odsId;
+  @JsonPropertyOrder("ods:type")
+  private String odsType;
+  @JsonProperty("oa:Selector")
+  private Selector oaSelector;
+
+  public Target withOdsId(String odsId) {
+    this.odsId = odsId;
+    return this;
+  }
+
+  public Target withOdsType(String odsType) {
+    this.odsType = odsType;
+    return this;
+  }
+
+  public Target withSelector(Selector oaSelector) {
+    this.oaSelector = oaSelector;
+    return this;
+  }
+
+
+}

--- a/src/main/java/eu/dissco/backend/domain/annotation/Target.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/Target.java
@@ -2,12 +2,12 @@ package eu.dissco.backend.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @NoArgsConstructor
-@RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 public class Target {
 


### PR DESCRIPTION
lotta boilerplate

Tried to align as closely with schema2pojo objects, e.g. Added allArgsConstructor and NoArgsConstructor and getters to each object because that's how the schema2pojo code is generated. 