### PR TITLE
Get MJR for specimens

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/DigitalMediaObjectController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalMediaObjectController.java
@@ -3,6 +3,7 @@ package eu.dissco.backend.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.backend.domain.AnnotationState;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
@@ -102,6 +103,20 @@ public class DigitalMediaObjectController extends BaseController {
     log.info("Received get request for mass for digital media: {}", id);
     var mass = service.getMass(id, getPath(request));
     return ResponseEntity.ok(mass);
+  }
+
+  @GetMapping(value = "/{prefix}/{suffix}/mjr", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonApiListResponseWrapper> getMasJobRecordForMedia(
+      @PathVariable("prefix") String prefix,
+      @PathVariable("suffix") String suffix,
+      @RequestParam(required = false)AnnotationState state,
+      @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
+      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
+      HttpServletRequest request
+  ) throws NotFoundException {
+    var path = getPath(request);
+    var id = prefix + '/' + suffix;
+    return ResponseEntity.ok(service.getMasJobRecordsForMedia(id, path, state, pageNumber, pageSize));
   }
 
   @PostMapping(value = "/{prefix}/{suffix}/mas", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/eu/dissco/backend/controller/SpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/SpecimenController.java
@@ -2,6 +2,7 @@ package eu.dissco.backend.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.backend.domain.AnnotationState;
 import eu.dissco.backend.domain.DigitalSpecimenJsonLD;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiRequestWrapper;
@@ -148,6 +149,21 @@ public class SpecimenController extends BaseController {
     log.info("Received get request for digitalmedia of specimen with id: {}", id);
     var digitalMedia = service.getDigitalMedia(id, getPath(request));
     return ResponseEntity.ok(digitalMedia);
+  }
+
+  @ResponseStatus(HttpStatus.OK)
+  @GetMapping(value = "/{prefix}/{suffix}/mjr", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonApiListResponseWrapper> getMasJobRecordsForSpecimen(
+      @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
+      @RequestParam(required = false) AnnotationState state,
+      @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
+      @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
+      HttpServletRequest request) throws NotFoundException {
+    var id = prefix + '/' + suffix;
+    log.info("Received ger request for MAS Job records for specimen {}", id);
+    String path = getPath(request);
+    return ResponseEntity.ok(
+        service.getMasJobRecordsForSpecimen(id, state, path, pageNumber, pageSize));
   }
 
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/eu/dissco/backend/repository/MasJobRecordRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/MasJobRecordRepository.java
@@ -35,6 +35,27 @@ public class MasJobRecordRepository {
         .fetchOptional(this::recordToMasJobRecord);
   }
 
+  public List<MasJobRecordFull> getMasJobRecordsByTargetId(String targetId, int pageNum, int pageSize) {
+    var offset = getOffset(pageNum, pageSize);
+    return context.select(MAS_JOB_RECORD.asterisk())
+        .from(MAS_JOB_RECORD)
+        .where(MAS_JOB_RECORD.TARGET_ID.eq(targetId))
+        .offset(offset)
+        .limit(pageSize)
+        .fetch(this::recordToMasJobRecord);
+  }
+
+  public List<MasJobRecordFull> getMasJobRecordsByTargetIdAndState(String targetId, String state, int pageNum, int pageSize) {
+    var offset = getOffset(pageNum, pageSize);
+    return context.select(MAS_JOB_RECORD.asterisk())
+        .from(MAS_JOB_RECORD)
+        .where(MAS_JOB_RECORD.TARGET_ID.eq(targetId))
+        .and(MAS_JOB_RECORD.STATE.eq(state))
+        .offset(offset)
+        .limit(pageSize)
+        .fetch(this::recordToMasJobRecord);
+  }
+
   public List<MasJobRecordFull> getMasJobRecordsByCreator(String creatorId, int pageNum, int pageSize){
     var offset = getOffset(pageNum, pageSize);
     return context.select(MAS_JOB_RECORD.asterisk())
@@ -45,7 +66,7 @@ public class MasJobRecordRepository {
         .fetch(this::recordToMasJobRecord);
   }
 
-  public List<MasJobRecordFull> getMasJobRecordsByCreatorAndStatus(String creatorId, String state, int pageNum, int pageSize){
+  public List<MasJobRecordFull> getMasJobRecordsByCreatorAndState(String creatorId, String state, int pageNum, int pageSize){
     var offset = getOffset(pageNum, pageSize);
     return context.select(MAS_JOB_RECORD.asterisk())
         .from(MAS_JOB_RECORD)

--- a/src/main/java/eu/dissco/backend/service/DigitalMediaObjectService.java
+++ b/src/main/java/eu/dissco/backend/service/DigitalMediaObjectService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import eu.dissco.backend.domain.AnnotationState;
 import eu.dissco.backend.domain.DigitalMediaObjectFull;
 import eu.dissco.backend.domain.DigitalMediaObjectWrapper;
 import eu.dissco.backend.domain.DigitalSpecimenWrapper;
@@ -37,6 +38,7 @@ public class DigitalMediaObjectService {
   private final MachineAnnotationServiceService masService;
   private final MongoRepository mongoRepository;
   private final ObjectMapper mapper;
+  private final MasJobRecordService masJobRecordService;
 
   // Controller Functions
   public JsonApiListResponseWrapper getDigitalMediaObjects(int pageNumber, int pageSize,
@@ -75,6 +77,11 @@ public class DigitalMediaObjectService {
     var dataNode = new JsonApiData(digitalMedia.digitalEntity().getOdsId(),
         digitalMedia.digitalEntity().getOdsType(), digitalMedia, mapper);
     return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
+  }
+
+  public JsonApiListResponseWrapper getMasJobRecordsForMedia(String targetId, String path,
+      AnnotationState state, int pageNum, int pageSize) throws NotFoundException {
+    return masJobRecordService.getMasJobRecordByTargetId(targetId, state, path, pageNum, pageSize);
   }
 
   private DigitalMediaObjectWrapper mapResultToDigitalMedia(JsonNode dataNode) {

--- a/src/main/java/eu/dissco/backend/service/SpecimenService.java
+++ b/src/main/java/eu/dissco/backend/service/SpecimenService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import eu.dissco.backend.domain.AnnotationState;
 import eu.dissco.backend.domain.DigitalSpecimenFull;
 import eu.dissco.backend.domain.DigitalSpecimenJsonLD;
 import eu.dissco.backend.domain.DigitalSpecimenWrapper;
@@ -63,6 +64,7 @@ public class SpecimenService {
   private final MachineAnnotationServiceService masService;
   private final AnnotationService annotationService;
   private final MongoRepository mongoRepository;
+  private final MasJobRecordService masJobRecordService;
 
   public JsonApiListResponseWrapper getSpecimen(int pageNumber, int pageSize, String path)
       throws IOException {
@@ -94,6 +96,11 @@ public class SpecimenService {
     var specimenNode = mongoRepository.getByVersion(id, version, MONGODB_COLLECTION_NAME);
     var specimen = mapResultToSpecimen(specimenNode);
     return mapFullSpecimen(id, path, specimen);
+  }
+
+  public JsonApiListResponseWrapper getMasJobRecordsForSpecimen(String targetId,
+      AnnotationState state, String path, int pageNum, int pageSize) throws NotFoundException {
+    return masJobRecordService.getMasJobRecordByTargetId(targetId, state, path, pageNum, pageSize);
   }
 
   private JsonApiWrapper mapFullSpecimen(String id, String path,

--- a/src/test/java/eu/dissco/backend/controller/DigitalMediaObjectControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/DigitalMediaObjectControllerTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.backend.domain.AnnotationState;
 import eu.dissco.backend.exceptions.ConflictException;
 import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.properties.ApplicationProperties;
@@ -119,6 +120,15 @@ class DigitalMediaObjectControllerTest {
     // Then
     assertThat(responseReceived.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(responseReceived.getBody()).isEqualTo(responseExpected);
+  }
+
+  @Test
+  void testGetMasJobRecordForMedia() throws Exception {
+    // When
+    var result = controller.getMasJobRecordForMedia(PREFIX, SUFFIX, AnnotationState.SCHEDULED, 1, 1, mockRequest);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/SpecimenControllerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.backend.domain.AnnotationState;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
@@ -123,6 +124,17 @@ class SpecimenControllerTest {
     var result = controller.getSpecimenAnnotations(PREFIX, SUFFIX, mockRequest);
 
     // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+
+  void testGetMjrsForSpecimen() throws Exception {
+
+    // When
+    var result = controller.getMasJobRecordsForSpecimen(PREFIX, SUFFIX, AnnotationState.SCHEDULED, 1, 1, mockRequest);
+
+    // THen
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 

--- a/src/test/java/eu/dissco/backend/service/DigitalMediaObjectServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalMediaObjectServiceTest.java
@@ -60,6 +60,8 @@ class DigitalMediaObjectServiceTest {
   private MongoRepository mongoRepository;
   @Mock
   private SpecimenRepository specimenRepository;
+  @Mock
+  MasJobRecordService masJobRecordService;
 
   private DigitalMediaObjectService service;
 
@@ -72,7 +74,7 @@ class DigitalMediaObjectServiceTest {
   @BeforeEach
   void setup() {
     service = new DigitalMediaObjectService(repository, annotationService, specimenRepository,
-        masService, mongoRepository, MAPPER);
+        masService, mongoRepository, MAPPER, masJobRecordService);
   }
 
   @ParameterizedTest

--- a/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
@@ -73,13 +73,15 @@ class SpecimenServiceTest {
   private MachineAnnotationServiceService masService;
   @Mock
   private MongoRepository mongoRepository;
+  @Mock
+  private MasJobRecordService masJobRecordService;
 
   private SpecimenService service;
 
   @BeforeEach
   void setup() {
     service = new SpecimenService(MAPPER, repository, elasticRepository, digitalMediaObjectService,
-        masService, annotationService, mongoRepository);
+        masService, annotationService, mongoRepository, masJobRecordService);
   }
 
   @Test


### PR DESCRIPTION
Given a digital specimen or media object, get Mas Job records for that object. Can filter on annotation state, can paginate.

If a DS is queried, it will not return MAS job records for associated media objects. Maybe that's something we want to add? 