### PR TITLE
Split creator id

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/MasJobRecordController.java
+++ b/src/main/java/eu/dissco/backend/controller/MasJobRecordController.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,7 +22,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 @RestController
-@RequestMapping("api/v1/mjr")
+@RequestMapping("/api/v1/mjr")
 public class MasJobRecordController extends BaseController {
 
   private final MasJobRecordService service;
@@ -54,10 +53,12 @@ public class MasJobRecordController extends BaseController {
 
   }
 
-  @PatchMapping(value = "/{creatorId}/{masJobId}/running")
+  @GetMapping(value = "/{creatorIdPrefix}/{creatorIdSuffix}/{masJobId}/running")
   public ResponseEntity<Void> markMjrAsRunning(
-      @PathVariable("creatorId") String creatorId,
+      @PathVariable("creatorIdPrefix") String creatorIdPrefix,
+      @PathVariable("creatorIdSuffix") String creatorIdSuffix,
       @PathVariable("masJobId") UUID masJobId) throws NotFoundException {
+    var creatorId = creatorIdPrefix + "/" + creatorIdSuffix;
     service.markMasJobRecordAsRunning(creatorId, masJobId);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/eu/dissco/backend/repository/MasJobRecordRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/MasJobRecordRepository.java
@@ -106,6 +106,7 @@ public class MasJobRecordRepository {
         .set(MAS_JOB_RECORD.STATE, AnnotationState.RUNNING.getState())
         .where(MAS_JOB_RECORD.JOB_ID.eq(masJobId))
         .and(MAS_JOB_RECORD.CREATOR_ID.eq(creatorId))
+        .and(MAS_JOB_RECORD.STATE.eq(AnnotationState.SCHEDULED.getState()))
         .execute();
   }
 

--- a/src/main/java/eu/dissco/backend/service/MasJobRecordService.java
+++ b/src/main/java/eu/dissco/backend/service/MasJobRecordService.java
@@ -97,7 +97,7 @@ public class MasJobRecordService {
 
   public void markMasJobRecordAsRunning(String creatorId, UUID masJobId) throws NotFoundException {
     if (masJobRecordRepository.markMasJobRecordAsRunning(creatorId, masJobId) == 0) {
-      throw new NotFoundException("Unable to locate MAS job with id " + masJobId);
+      throw new NotFoundException("Unable to locate scheduled MAS job with id " + masJobId);
     }
   }
 

--- a/src/test/java/eu/dissco/backend/controller/MasJobRecordControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/MasJobRecordControllerTest.java
@@ -1,8 +1,9 @@
 package eu.dissco.backend.controller;
 
-import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.ORCID;
+import static eu.dissco.backend.TestUtils.PREFIX;
+import static eu.dissco.backend.TestUtils.SUFFIX;
 import static eu.dissco.backend.utils.MasJobRecordUtils.JOB_ID;
 import static eu.dissco.backend.utils.MasJobRecordUtils.MJR_URI;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -73,7 +74,7 @@ class MasJobRecordControllerTest {
   @Test
   void testMarkMjrAsRunning() throws Exception {
     // When
-    var result = controller.markMjrAsRunning(ID, JOB_ID);
+    var result = controller.markMjrAsRunning(PREFIX, SUFFIX, JOB_ID);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/eu/dissco/backend/repository/MasJobRecordRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/MasJobRecordRepositoryIT.java
@@ -191,6 +191,23 @@ class MasJobRecordRepositoryIT extends BaseRepositoryIT {
     assertThat(state).isEqualTo(AnnotationState.RUNNING.getState());
   }
 
+  @Test
+  void testMarkMasJobRecordAsRunningCompleted() throws Exception {
+    // Given
+    postMasJobRecordFull(List.of(givenMasJobRecordFullCompleted()));
+
+    // When
+    masJobRecordRepository.markMasJobRecordAsRunning(ID_ALT, JOB_ID);
+    var result = context.select(MAS_JOB_RECORD.JOB_ID, MAS_JOB_RECORD.STATE)
+        .from(MAS_JOB_RECORD)
+        .where(MAS_JOB_RECORD.JOB_ID.eq(JOB_ID))
+        .fetchOptional();
+
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
   private void postMasJobRecordFull(List<MasJobRecordFull> mjrList) throws JsonProcessingException {
     for (var mjr : mjrList) {
       context.insertInto(MAS_JOB_RECORD)


### PR DESCRIPTION
- Split creator id in /running endpoint
- Change to GET request to allow securityfilterchain to permit this function without authentication
- Only SCHEDULED jobs can be set to RUNNING