### PR TITLE
add batching requested to kafka object

### DIFF
--- a/src/main/java/eu/dissco/backend/domain/MasTarget.java
+++ b/src/main/java/eu/dissco/backend/domain/MasTarget.java
@@ -3,7 +3,8 @@ package eu.dissco.backend.domain;
 
 public record MasTarget(
     Object object,
-    String jobId
+    String jobId,
+    Boolean batchingRequested
 ) {
 
 

--- a/src/main/java/eu/dissco/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/backend/service/MachineAnnotationServiceService.java
@@ -95,7 +95,7 @@ public class MachineAnnotationServiceService {
     for (var masRecord : availableRecords) {
       var mjr = masJobRecordIdMap.get(masRecord.id());
       try {
-        var targetObject = new MasTarget(object, mjr.jobId());
+        var targetObject = new MasTarget(object, mjr.jobId(), batchingRequested);
         kafkaPublisherService.sendObjectToQueue(masRecord.mas().topicName(), targetObject);
         scheduledJobs.add(
             new JsonApiData(mjr.jobId(), "MachineAnnotationServiceJobRecord", mjr, mapper));

--- a/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
@@ -117,7 +117,7 @@ class MachineAnnotationServiceServiceTest {
     given(masJobRecordService.createMasJobRecord(Set.of(masRecord), ID, ORCID,
         MjrTargetType.DIGITAL_SPECIMEN, false)).willReturn(
         givenMasJobRecordIdMap(masRecord.id()));
-    var sendObject = new MasTarget(digitalSpecimen, JOB_ID);
+    var sendObject = new MasTarget(digitalSpecimen, JOB_ID, false);
 
     // When
     var result = service.scheduleMass(givenFlattenedDigitalSpecimen(), List.of(ID), SPECIMEN_PATH,
@@ -172,7 +172,7 @@ class MachineAnnotationServiceServiceTest {
     given(masJobRecordService.createMasJobRecord(Set.of(masRecord), ID, ORCID,
         MjrTargetType.DIGITAL_SPECIMEN, false)).willReturn(
         givenMasJobRecordIdMap(masRecord.id()));
-    var sendObject = new MasTarget(digitalSpecimenWrapper, JOB_ID);
+    var sendObject = new MasTarget(digitalSpecimenWrapper, JOB_ID, false);
     willThrow(JsonProcessingException.class).given(kafkaPublisherService)
         .sendObjectToQueue("fancy-topic-name", sendObject);
 


### PR DESCRIPTION
Lets MASs know if batching was requested for their service. May be ignored by MASs that do not implement batching. 

Kafka object now is: 

```
{
   "object": [digital specimen], 
   "jobId" : [jobId], 
   "batchingRequested" : true/false
}
```