### PR TITLE
Add batching per masJobRequest

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/BaseController.java
+++ b/src/main/java/eu/dissco/backend/controller/BaseController.java
@@ -1,13 +1,16 @@
 package eu.dissco.backend.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.backend.exceptions.ConflictException;
 import eu.dissco.backend.properties.ApplicationProperties;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 
@@ -18,6 +21,8 @@ public abstract class BaseController {
   public static final String DATE_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
   protected static final String DEFAULT_PAGE_NUM = "1";
   protected static final String DEFAULT_PAGE_SIZE = "10";
+  private static final TypeReference<List<MasJobRequest>> LIST_TYPE = new TypeReference<>() {
+  };
   protected final ObjectMapper mapper;
   private final ApplicationProperties applicationProperties;
 
@@ -30,16 +35,16 @@ public abstract class BaseController {
     return path;
   }
 
-  protected List<String> getMassFromRequest(JsonApiRequestWrapper requestBody)
-      throws JsonProcessingException, ConflictException {
+  protected Map<String, MasJobRequest> getMassRequestFromRequest(JsonApiRequestWrapper requestBody)
+      throws ConflictException {
     if (!requestBody.data().type().equals("MasRequest")) {
       throw new ConflictException();
     }
     if (requestBody.data().attributes().get("mass") == null) {
       throw new IllegalArgumentException();
     }
-    return Arrays.asList(
-        mapper.treeToValue(requestBody.data().attributes().get("mass"), String[].class));
+    var list = mapper.convertValue(requestBody.data().attributes().get("mass"), LIST_TYPE);
+    return list.stream().collect(Collectors.toMap(MasJobRequest::masId, Function.identity()));
   }
 
 }

--- a/src/main/java/eu/dissco/backend/controller/DigitalMediaObjectController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalMediaObjectController.java
@@ -14,7 +14,6 @@ import eu.dissco.backend.exceptions.PidCreationException;
 import eu.dissco.backend.properties.ApplicationProperties;
 import eu.dissco.backend.service.DigitalMediaObjectService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -120,21 +119,23 @@ public class DigitalMediaObjectController extends BaseController {
   ) throws NotFoundException {
     var path = getPath(request);
     var id = prefix + '/' + suffix;
-    return ResponseEntity.ok(service.getMasJobRecordsForMedia(id, path, state, pageNumber, pageSize));
+    return ResponseEntity.ok(
+        service.getMasJobRecordsForMedia(id, path, state, pageNumber, pageSize));
   }
 
   @PostMapping(value = "/{prefix}/{suffix}/mas", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> scheduleMassForDigitalMediaObject(
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
-      @RequestParam(defaultValue = "false") boolean batching,
-      @RequestBody JsonApiRequestWrapper requestBody, Authentication authentication, HttpServletRequest request)
-      throws JsonProcessingException, ConflictException, ForbiddenException, PidCreationException {
+      @RequestBody JsonApiRequestWrapper requestBody, Authentication authentication,
+      HttpServletRequest request)
+      throws ConflictException, ForbiddenException, PidCreationException {
     var userId = authentication.getName();
     var id = prefix + '/' + suffix;
-    var masIds = getMassFromRequest(requestBody);
-    log.info("Received request to schedule all relevant MASs of: {} on digital media: {}", masIds,
+    var masRequests = getMassRequestFromRequest(requestBody);
+    log.info("Received request to schedule all relevant MASs of: {} on digital media: {}",
+        masRequests,
         id);
-    var massResponse = service.scheduleMass(id, masIds, getPath(request), userId, batching);
+    var massResponse = service.scheduleMass(id, masRequests, getPath(request), userId);
     return ResponseEntity.accepted().body(massResponse);
   }
 

--- a/src/main/java/eu/dissco/backend/controller/SpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/SpecimenController.java
@@ -232,16 +232,15 @@ public class SpecimenController extends BaseController {
   @PostMapping(value = "/{prefix}/{suffix}/mas", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> scheduleMassForDigitalSpecimen(
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
-      @RequestParam(defaultValue = "false") boolean batching,
       @RequestBody JsonApiRequestWrapper requestBody, Authentication authentication,
       HttpServletRequest request)
-      throws JsonProcessingException, ConflictException, ForbiddenException, PidCreationException {
+      throws ConflictException, ForbiddenException, PidCreationException {
     var userId = authentication.getName();
     var id = prefix + '/' + suffix;
-    var masIds = getMassFromRequest(requestBody);
+    var masRequests = getMassRequestFromRequest(requestBody);
     log.info("Received request to schedule all relevant MASs for: {} on digital specimen: {}",
-        masIds, id);
-    var massResponse = service.scheduleMass(id, masIds, userId, getPath(request), batching);
+        masRequests, id);
+    var massResponse = service.scheduleMass(id, masRequests, userId, getPath(request));
     return ResponseEntity.accepted().body(massResponse);
   }
 

--- a/src/main/java/eu/dissco/backend/domain/MachineAnnotationService.java
+++ b/src/main/java/eu/dissco/backend/domain/MachineAnnotationService.java
@@ -9,11 +9,17 @@ public record MachineAnnotationService(
     @NotBlank String containerImage,
     @NotBlank String containerTag,
     JsonNode targetDigitalObjectFilters,
-    String serviceDescription, String serviceState,
-    String sourceCodeRepository, String serviceAvailability,
-    String codeMaintainer, String codeLicense,
-    List<String> dependencies, String supportContact,
-    String slaDocumentation, String topicName, int maxReplicas,
+    String serviceDescription,
+    String serviceState,
+    String sourceCodeRepository,
+    String serviceAvailability,
+    String codeMaintainer,
+    String codeLicense,
+    List<String> dependencies,
+    String supportContact,
+    String slaDocumentation,
+    String topicName,
+    int maxReplicas,
     @NotBlank boolean batchingRequested) {
 
 }

--- a/src/main/java/eu/dissco/backend/domain/MasJobRequest.java
+++ b/src/main/java/eu/dissco/backend/domain/MasJobRequest.java
@@ -1,0 +1,8 @@
+package eu.dissco.backend.domain;
+
+public record MasJobRequest(
+    String masId,
+    boolean batching
+) {
+
+}

--- a/src/main/java/eu/dissco/backend/repository/MachineAnnotationServiceRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/MachineAnnotationServiceRepository.java
@@ -11,6 +11,7 @@ import eu.dissco.backend.domain.MachineAnnotationServiceRecord;
 import eu.dissco.backend.exceptions.DisscoJsonBMappingException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.jooq.JSONB;
@@ -71,7 +72,7 @@ public class MachineAnnotationServiceRepository {
     return mapper.createObjectNode();
   }
 
-  public List<MachineAnnotationServiceRecord> getMasRecords(List<String> mass) {
+  public List<MachineAnnotationServiceRecord> getMasRecords(Set<String> mass) {
     return context.selectFrom(MACHINE_ANNOTATION_SERVICES)
         .where(MACHINE_ANNOTATION_SERVICES.ID.in(mass))
         .and(MACHINE_ANNOTATION_SERVICES.DELETED_ON.isNull())

--- a/src/main/java/eu/dissco/backend/service/DigitalMediaObjectService.java
+++ b/src/main/java/eu/dissco/backend/service/DigitalMediaObjectService.java
@@ -12,6 +12,7 @@ import eu.dissco.backend.database.jooq.enums.MjrTargetType;
 import eu.dissco.backend.domain.DigitalMediaObjectFull;
 import eu.dissco.backend.domain.DigitalMediaObjectWrapper;
 import eu.dissco.backend.domain.DigitalSpecimenWrapper;
+import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
@@ -27,6 +28,7 @@ import eu.dissco.backend.repository.SpecimenRepository;
 import eu.dissco.backend.schema.DigitalEntity;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -163,13 +165,15 @@ public class DigitalMediaObjectService {
     return objectNode;
   }
 
-  public JsonApiListResponseWrapper scheduleMass(String id, List<String> mass, String path, String userId, boolean batchingRequested)
+  public JsonApiListResponseWrapper scheduleMass(String id, Map<String, MasJobRequest> masRequests,
+      String path, String userId)
       throws ForbiddenException, PidCreationException, ConflictException {
     var orcid = userService.getOrcid(userId);
     var digitalMedia = repository.getLatestDigitalMediaObjectById(id);
     var digitalSpecimen = specimenRepository.getLatestSpecimenById(getDsDoiFromDmo(digitalMedia));
     var flattenObjectData = flattenAttributes(digitalMedia, digitalSpecimen);
-    return masService.scheduleMass(flattenObjectData, mass, path, digitalMedia, id, orcid, MjrTargetType.MEDIA_OBJECT, batchingRequested);
+    return masService.scheduleMass(flattenObjectData, masRequests, path, digitalMedia, id, orcid,
+        MjrTargetType.MEDIA_OBJECT);
   }
 
 }

--- a/src/main/java/eu/dissco/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/backend/service/MachineAnnotationServiceService.java
@@ -83,8 +83,7 @@ public class MachineAnnotationServiceService {
 
   public JsonApiListResponseWrapper scheduleMass(JsonNode flattenObjectData,
       Map<String, MasJobRequest> masRequests, String path, Object object, String targetId,
-      String orcid,
-      MjrTargetType targetType) throws ConflictException {
+      String orcid, MjrTargetType targetType) throws ConflictException {
     var masRecords = repository.getMasRecords(masRequests.keySet());
     validateBatchingRequest(masRequests, masRecords);
     var scheduledJobs = new ArrayList<JsonApiData>();

--- a/src/main/java/eu/dissco/backend/service/MasJobRecordService.java
+++ b/src/main/java/eu/dissco/backend/service/MasJobRecordService.java
@@ -6,6 +6,7 @@ import eu.dissco.backend.database.jooq.enums.MjrTargetType;
 import eu.dissco.backend.domain.MachineAnnotationServiceRecord;
 import eu.dissco.backend.domain.MasJobRecord;
 import eu.dissco.backend.domain.MasJobRecordFull;
+import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
@@ -13,12 +14,10 @@ import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.repository.MasJobRecordRepository;
-
 import eu.dissco.backend.web.HandleComponent;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -92,17 +91,25 @@ public class MasJobRecordService {
     return new JsonApiListResponseWrapper(dataList, linksNode);
   }
 
-  public Map<String, MasJobRecord> createMasJobRecord(Set<MachineAnnotationServiceRecord> masRecords,
-      String targetId, String orcid, MjrTargetType targetType, boolean batchingRequested) {
+  public Map<String, MasJobRecord> createMasJobRecord(
+      Set<MachineAnnotationServiceRecord> masRecords,
+      String targetId, String orcid, MjrTargetType targetType, Map<String, MasJobRequest> mass) {
     log.info("Requesting {} handles from API", masRecords.size());
     var handles = handleComponent.postHandle(masRecords.size());
     var handleItr = handles.iterator();
     var masJobRecordList = masRecords.stream()
-        .map(masRecord -> new MasJobRecord(handleItr.next(), MjrJobState.SCHEDULED, masRecord.id(), targetId, targetType,
-            orcid, batchingRequested))
+        .map(masRecord -> new MasJobRecord(
+            handleItr.next(),
+            MjrJobState.SCHEDULED,
+            masRecord.id(),
+            targetId,
+            targetType,
+            orcid,
+            mass.get(masRecord.id()).batching()))
         .toList();
     masJobRecordRepository.createNewMasJobRecord(masJobRecordList);
-    return masJobRecordList.stream().collect(Collectors.toMap(MasJobRecord::masId, Function.identity()));
+    return masJobRecordList.stream()
+        .collect(Collectors.toMap(MasJobRecord::masId, Function.identity()));
   }
 
   public void markMasJobRecordAsRunning(String masId, String jobId) throws NotFoundException {

--- a/src/main/java/eu/dissco/backend/service/SpecimenService.java
+++ b/src/main/java/eu/dissco/backend/service/SpecimenService.java
@@ -12,11 +12,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.backend.database.jooq.enums.MjrJobState;
 import eu.dissco.backend.database.jooq.enums.MjrTargetType;
+import eu.dissco.backend.domain.DefaultMappingTerms;
 import eu.dissco.backend.domain.DigitalSpecimenFull;
 import eu.dissco.backend.domain.DigitalSpecimenJsonLD;
 import eu.dissco.backend.domain.DigitalSpecimenWrapper;
 import eu.dissco.backend.domain.MappingTerm;
-import eu.dissco.backend.domain.DefaultMappingTerms;
+import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.TaxonMappingTerms;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
@@ -337,7 +338,8 @@ public class SpecimenService {
     var mappedParams = mapParamsKeyword(params, getParamMapping());
     var map = mappedParams.entrySet().stream()
         .collect(Collectors.toMap(entry -> entry.getKey().fullName(), Entry::getValue));
-    var aggregations = elasticRepository.getAggregations(map, DefaultMappingTerms.getAggregationSet(),
+    var aggregations = elasticRepository.getAggregations(map,
+        DefaultMappingTerms.getAggregationSet(),
         false);
     var dataNode = new JsonApiData(String.valueOf(params.hashCode()), AGGREGATIONS_TYPE,
         mapper.valueToTree(aggregations));
@@ -376,14 +378,14 @@ public class SpecimenService {
     return mapper.convertValue(digitalSpecimen.digitalSpecimen(), ObjectNode.class);
   }
 
-  public JsonApiListResponseWrapper scheduleMass(String id, List<String> masIds, String userId,
-      String path, boolean batchingRequested)
+  public JsonApiListResponseWrapper scheduleMass(String id, Map<String, MasJobRequest> masRequests,
+      String userId, String path)
       throws ForbiddenException, ConflictException {
     var orcid = userService.getOrcid(userId);
     var digitalSpecimen = repository.getLatestSpecimenById(id);
     var flattenAttributes = flattenAttributes(digitalSpecimen);
-    return masService.scheduleMass(flattenAttributes, masIds, path, digitalSpecimen, id, orcid,
-        MjrTargetType.DIGITAL_SPECIMEN, batchingRequested);
+    return masService.scheduleMass(flattenAttributes, masRequests, path, digitalSpecimen, id, orcid,
+        MjrTargetType.DIGITAL_SPECIMEN);
   }
 
 

--- a/src/test/java/eu/dissco/backend/controller/DigitalMediaObjectControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/DigitalMediaObjectControllerTest.java
@@ -9,6 +9,7 @@ import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationJsonRespons
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.DIGITAL_MEDIA_PATH;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.DIGITAL_MEDIA_URI;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaJsonResponse;
+import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -23,7 +24,7 @@ import eu.dissco.backend.properties.ApplicationProperties;
 import eu.dissco.backend.service.DigitalMediaObjectService;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -129,7 +130,8 @@ class DigitalMediaObjectControllerTest {
   @Test
   void testGetMasJobRecordForMedia() throws Exception {
     // When
-    var result = controller.getMasJobRecordForMedia(PREFIX, SUFFIX, MjrJobState.SCHEDULED, 1, 1, mockRequest);
+    var result = controller.getMasJobRecordForMedia(PREFIX, SUFFIX, MjrJobState.SCHEDULED, 1, 1,
+        mockRequest);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -156,11 +158,13 @@ class DigitalMediaObjectControllerTest {
     var expectedResponse = givenMasResponse(DIGITAL_MEDIA_PATH);
     var request = givenMasRequest();
     givenAuthentication();
-    given(service.scheduleMass(ID, List.of(ID), DIGITAL_MEDIA_PATH, USER_ID_TOKEN, false)).willReturn(expectedResponse);
+    given(service.scheduleMass(ID, Map.of(ID, givenMasJobRequest()), DIGITAL_MEDIA_PATH,
+        USER_ID_TOKEN)).willReturn(expectedResponse);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 
     // When
-    var result = controller.scheduleMassForDigitalMediaObject(PREFIX, SUFFIX, false, request, authentication, mockRequest);
+    var result = controller.scheduleMassForDigitalMediaObject(PREFIX, SUFFIX, request,
+        authentication, mockRequest);
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
@@ -175,7 +179,8 @@ class DigitalMediaObjectControllerTest {
 
     // When / Then
     assertThrowsExactly(ConflictException.class,
-        () -> controller.scheduleMassForDigitalMediaObject(PREFIX, SUFFIX, false, request, authentication, mockRequest));
+        () -> controller.scheduleMassForDigitalMediaObject(PREFIX, SUFFIX, request, authentication,
+            mockRequest));
   }
 
   private void givenAuthentication() {

--- a/src/test/java/eu/dissco/backend/repository/MachineAnnotationServiceRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/MachineAnnotationServiceRepositoryIT.java
@@ -10,6 +10,7 @@ import eu.dissco.backend.domain.MachineAnnotationServiceRecord;
 import eu.dissco.backend.utils.MachineAnnotationServiceUtils;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.jooq.JSONB;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,8 +48,7 @@ class MachineAnnotationServiceRepositoryIT extends BaseRepositoryIT {
     populateDatabase();
 
     // When
-    var result = repository.getMasRecords(
-        List.of(PREFIX + "ABC-123-XY14", PREFIX + "ABC-123-XY18"));
+    var result = repository.getMasRecords(Set.of(PREFIX + "ABC-123-XY14", PREFIX + "ABC-123-XY18"));
 
     // Then
     assertThat(result).hasSize(2);

--- a/src/test/java/eu/dissco/backend/service/DigitalMediaObjectServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalMediaObjectServiceTest.java
@@ -16,6 +16,7 @@ import static eu.dissco.backend.utils.DigitalMediaObjectUtils.DIGITAL_MEDIA_PATH
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaJsonApiData;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaJsonResponse;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaObject;
+import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +41,7 @@ import eu.dissco.backend.schema.EntityRelationships;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -296,12 +298,15 @@ class DigitalMediaObjectServiceTest {
     var response = givenMasResponse(DIGITAL_MEDIA_PATH);
     given(repository.getLatestDigitalMediaObjectById(ID)).willReturn(digitalMediaWrapper);
     given(specimenRepository.getLatestSpecimenById(ID_ALT)).willReturn(digitalSpecimen);
-    given(masService.scheduleMass(any(JsonNode.class), eq(List.of(ID)), eq(DIGITAL_MEDIA_PATH),
-        eq(digitalMediaWrapper), eq(ID), eq(ORCID), eq(MjrTargetType.MEDIA_OBJECT), eq(false))).willReturn(response);
+    given(masService.scheduleMass(any(JsonNode.class), eq(Map.of(ID, givenMasJobRequest())),
+        eq(DIGITAL_MEDIA_PATH),
+        eq(digitalMediaWrapper), eq(ID), eq(ORCID), eq(MjrTargetType.MEDIA_OBJECT))).willReturn(
+        response);
     given(userService.getOrcid(USER_ID_TOKEN)).willReturn(ORCID);
 
     // When
-    var result = service.scheduleMass(ID, List.of(ID), DIGITAL_MEDIA_PATH, USER_ID_TOKEN, false);
+    var result = service.scheduleMass(ID, Map.of(ID, givenMasJobRequest()), DIGITAL_MEDIA_PATH,
+        USER_ID_TOKEN);
 
     // Then
     assertThat(result).isEqualTo(response);

--- a/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
@@ -5,9 +5,9 @@ import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.givenDigitalSpecimenWrapper;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.DIGITAL_MEDIA_PATH;
-import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaObject;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenFlattenedDigitalMedia;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenFlattenedDigitalSpecimen;
+import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasRecord;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenScheduledMasResponse;
@@ -25,15 +25,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.backend.database.jooq.enums.MjrTargetType;
 import eu.dissco.backend.domain.MasTarget;
-import eu.dissco.backend.exceptions.ConflictException;
-import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiMeta;
-import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
+import eu.dissco.backend.exceptions.ConflictException;
 import eu.dissco.backend.repository.MachineAnnotationServiceRepository;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
@@ -113,15 +112,18 @@ class MachineAnnotationServiceServiceTest {
     // Given
     var digitalSpecimen = givenDigitalSpecimenWrapper(ID);
     var masRecord = givenMasRecord(givenFiltersDigitalSpecimen());
-    given(repository.getMasRecords(List.of(ID))).willReturn(List.of(masRecord));
+    given(repository.getMasRecords(Set.of(ID))).willReturn(List.of(masRecord));
     given(masJobRecordService.createMasJobRecord(Set.of(masRecord), ID, ORCID,
-        MjrTargetType.DIGITAL_SPECIMEN, false)).willReturn(
+        MjrTargetType.DIGITAL_SPECIMEN, Map.of(ID, givenMasJobRequest()))).willReturn(
         givenMasJobRecordIdMap(masRecord.id()));
     var sendObject = new MasTarget(digitalSpecimen, JOB_ID, false);
 
     // When
-    var result = service.scheduleMass(givenFlattenedDigitalSpecimen(), List.of(ID), SPECIMEN_PATH,
-        digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID, MjrTargetType.DIGITAL_SPECIMEN, false);
+    var result = service.scheduleMass(givenFlattenedDigitalSpecimen(),
+        Map.of(ID, givenMasJobRequest()),
+        SPECIMEN_PATH,
+        digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID,
+        MjrTargetType.DIGITAL_SPECIMEN);
 
     // Then
     assertThat(result).isEqualTo(givenScheduledMasResponse(givenMasJobRecord(), SPECIMEN_PATH));
@@ -133,7 +135,7 @@ class MachineAnnotationServiceServiceTest {
     // Given
     var digitalSpecimen = givenDigitalSpecimenWrapper(ID);
     var masRecord = givenMasRecord(givenFiltersDigitalMedia(true));
-    given(repository.getMasRecords(List.of(ID))).willReturn(List.of(masRecord));
+    given(repository.getMasRecords(Set.of(ID))).willReturn(List.of(masRecord));
     var expected = new JsonApiListResponseWrapper(
         Collections.emptyList(),
         new JsonApiLinksFull(SPECIMEN_PATH),
@@ -141,9 +143,11 @@ class MachineAnnotationServiceServiceTest {
     );
 
     // When
-    var result = service.scheduleMass(givenFlattenedDigitalSpecimen(), List.of(ID), SPECIMEN_PATH,
+    var result = service.scheduleMass(givenFlattenedDigitalSpecimen(),
+        Map.of(ID, givenMasJobRequest()),
+        SPECIMEN_PATH,
         digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID,
-        MjrTargetType.DIGITAL_SPECIMEN, false);
+        MjrTargetType.DIGITAL_SPECIMEN);
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -156,11 +160,14 @@ class MachineAnnotationServiceServiceTest {
     // Given
     var digitalSpecimen = givenDigitalSpecimenWrapper(ID);
     var masRecord = givenMasRecord(givenFiltersDigitalSpecimen());
-    given(repository.getMasRecords(List.of(ID))).willReturn(List.of(masRecord));
+    given(repository.getMasRecords(Set.of(ID))).willReturn(List.of(masRecord));
 
     // Then
-    assertThrows(ConflictException.class, () -> service.scheduleMass(givenFlattenedDigitalSpecimen(), List.of(ID), SPECIMEN_PATH,
-        digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID, MjrTargetType.DIGITAL_SPECIMEN, true));
+    assertThrows(ConflictException.class,
+        () -> service.scheduleMass(givenFlattenedDigitalSpecimen(),
+            Map.of(ID, givenMasJobRequest(true)), SPECIMEN_PATH,
+            digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID,
+            MjrTargetType.DIGITAL_SPECIMEN));
   }
 
   @Test
@@ -168,17 +175,19 @@ class MachineAnnotationServiceServiceTest {
     // Given
     var digitalSpecimenWrapper = givenDigitalSpecimenWrapper(ID);
     var masRecord = givenMasRecord(givenFiltersDigitalSpecimen());
-    given(repository.getMasRecords(List.of(ID))).willReturn(List.of(masRecord));
+    given(repository.getMasRecords(Set.of(ID))).willReturn(List.of(masRecord));
     given(masJobRecordService.createMasJobRecord(Set.of(masRecord), ID, ORCID,
-        MjrTargetType.DIGITAL_SPECIMEN, false)).willReturn(
+        MjrTargetType.DIGITAL_SPECIMEN, Map.of(ID, givenMasJobRequest()))).willReturn(
         givenMasJobRecordIdMap(masRecord.id()));
     var sendObject = new MasTarget(digitalSpecimenWrapper, JOB_ID, false);
     willThrow(JsonProcessingException.class).given(kafkaPublisherService)
         .sendObjectToQueue("fancy-topic-name", sendObject);
 
     // When
-    var result = service.scheduleMass(givenFlattenedDigitalSpecimen(), List.of(ID), SPECIMEN_PATH,
-        digitalSpecimenWrapper, digitalSpecimenWrapper.digitalSpecimen().getOdsId(), ORCID, MjrTargetType.DIGITAL_SPECIMEN, false);
+    var result = service.scheduleMass(givenFlattenedDigitalSpecimen(),
+        Map.of(ID, givenMasJobRequest()), SPECIMEN_PATH,
+        digitalSpecimenWrapper, digitalSpecimenWrapper.digitalSpecimen().getOdsId(), ORCID,
+        MjrTargetType.DIGITAL_SPECIMEN);
 
     // Then
     then(masJobRecordService).should().markMasJobRecordAsFailed(List.of(JOB_ID));

--- a/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
@@ -111,22 +111,21 @@ class MachineAnnotationServiceServiceTest {
   void testScheduleMass() throws JsonProcessingException, ConflictException {
     // Given
     var digitalSpecimen = givenDigitalSpecimenWrapper(ID);
-    var masRecord = givenMasRecord(givenFiltersDigitalSpecimen());
+    var masRecord = givenMasRecord(givenFiltersDigitalSpecimen(), true);
     given(repository.getMasRecords(Set.of(ID))).willReturn(List.of(masRecord));
     given(masJobRecordService.createMasJobRecord(Set.of(masRecord), ID, ORCID,
-        MjrTargetType.DIGITAL_SPECIMEN, Map.of(ID, givenMasJobRequest()))).willReturn(
-        givenMasJobRecordIdMap(masRecord.id()));
-    var sendObject = new MasTarget(digitalSpecimen, JOB_ID, false);
+        MjrTargetType.DIGITAL_SPECIMEN, Map.of(ID, givenMasJobRequest(true)))).willReturn(
+        givenMasJobRecordIdMap(masRecord.id(), true));
+    var sendObject = new MasTarget(digitalSpecimen, JOB_ID, true);
 
     // When
     var result = service.scheduleMass(givenFlattenedDigitalSpecimen(),
-        Map.of(ID, givenMasJobRequest()),
-        SPECIMEN_PATH,
-        digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID,
+        Map.of(ID, givenMasJobRequest(true)),
+        SPECIMEN_PATH, digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID,
         MjrTargetType.DIGITAL_SPECIMEN);
 
     // Then
-    assertThat(result).isEqualTo(givenScheduledMasResponse(givenMasJobRecord(), SPECIMEN_PATH));
+    assertThat(result).isEqualTo(givenScheduledMasResponse(givenMasJobRecord(true), SPECIMEN_PATH));
     then(kafkaPublisherService).should().sendObjectToQueue("fancy-topic-name", sendObject);
   }
 

--- a/src/test/java/eu/dissco/backend/service/MasJobRecordServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MasJobRecordServiceTest.java
@@ -5,6 +5,7 @@ import static eu.dissco.backend.TestUtils.ID_ALT;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.USER_ID_TOKEN;
+import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasRecord;
 import static eu.dissco.backend.utils.MasJobRecordUtils.JOB_ID;
 import static eu.dissco.backend.utils.MasJobRecordUtils.MJR_URI;
@@ -28,6 +29,7 @@ import eu.dissco.backend.repository.MasJobRecordRepository;
 import eu.dissco.backend.web.HandleComponent;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,11 +41,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MasJobRecordServiceTest {
 
+  @Mock
+  HandleComponent handleComponent;
   private MasJobRecordService masJobRecordService;
   @Mock
   private MasJobRecordRepository masJobRecordRepository;
-  @Mock
-  HandleComponent handleComponent;
 
   @BeforeEach
   void setup() {
@@ -179,7 +181,8 @@ class MasJobRecordServiceTest {
     given(handleComponent.postHandle(1)).willReturn(List.of(JOB_ID));
 
     // When
-    var result = masJobRecordService.createMasJobRecord(Set.of(masRecord), ID_ALT, ORCID, MjrTargetType.DIGITAL_SPECIMEN, false);
+    var result = masJobRecordService.createMasJobRecord(Set.of(masRecord), ID_ALT, ORCID,
+        MjrTargetType.DIGITAL_SPECIMEN, Map.of(masRecord.id(), givenMasJobRequest()));
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/SpecimenServiceTest.java
@@ -18,6 +18,7 @@ import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationJsonRespons
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationResponse;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaJsonApiData;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaObject;
+import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
 import static eu.dissco.backend.utils.SpecimenUtils.SPECIMEN_PATH;
 import static eu.dissco.backend.utils.SpecimenUtils.givenDigitalSpecimenJsonApiData;
@@ -456,7 +457,8 @@ class SpecimenServiceTest {
     params.put("sourceSystemId", List.of(SOURCE_SYSTEM_ID_1));
     var map = new MultiValueMapAdapter<>(params);
     var aggregationMap = givenAggregationMap();
-    given(elasticRepository.getAggregations(anyMap(), anySet(), eq(false))).willReturn(aggregationMap);
+    given(elasticRepository.getAggregations(anyMap(), anySet(), eq(false))).willReturn(
+        aggregationMap);
     var dataNode = new JsonApiData(String.valueOf(params.hashCode()), "aggregations",
         MAPPER.valueToTree(aggregationMap));
     var linksNode = new JsonApiLinks(SPECIMEN_PATH);
@@ -476,7 +478,8 @@ class SpecimenServiceTest {
     params.put("kingdom", List.of("animalia"));
     var map = new MultiValueMapAdapter<>(params);
     var aggregationMap = givenTaxonAggregationMap();
-    given(elasticRepository.getAggregations(anyMap(), anySet(), eq(true))).willReturn(aggregationMap);
+    given(elasticRepository.getAggregations(anyMap(), anySet(), eq(true))).willReturn(
+        aggregationMap);
     var dataNode = new JsonApiData(String.valueOf(params.hashCode()), "aggregations",
         MAPPER.valueToTree(aggregationMap));
     var linksNode = new JsonApiLinks(SPECIMEN_PATH);
@@ -555,14 +558,16 @@ class SpecimenServiceTest {
     var digitalSpecimenWrapper = givenDigitalSpecimenWrapper(ID);
     var response = givenMasResponse(SPECIMEN_PATH);
     given(repository.getLatestSpecimenById(ID)).willReturn(digitalSpecimenWrapper);
-    given(masService.scheduleMass(any(JsonNode.class), eq(List.of(ID)), eq(SPECIMEN_PATH),
+    given(masService.scheduleMass(any(JsonNode.class), eq(Map.of(ID, givenMasJobRequest())),
+        eq(SPECIMEN_PATH),
         eq(digitalSpecimenWrapper),
         eq(digitalSpecimenWrapper.digitalSpecimen().getOdsId()), eq(ORCID),
-        eq(MjrTargetType.DIGITAL_SPECIMEN), eq(false))).willReturn(response);
+        eq(MjrTargetType.DIGITAL_SPECIMEN))).willReturn(response);
     given(userService.getOrcid(USER_ID_TOKEN)).willReturn(ORCID);
 
     // When
-    var result = service.scheduleMass(ID, List.of(ID), USER_ID_TOKEN, SPECIMEN_PATH, false);
+    var result = service.scheduleMass(ID, Map.of(ID, givenMasJobRequest()), USER_ID_TOKEN,
+        SPECIMEN_PATH);
 
     // Then
     assertThat(result).isEqualTo(response);

--- a/src/test/java/eu/dissco/backend/utils/MachineAnnotationServiceUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/MachineAnnotationServiceUtils.java
@@ -86,12 +86,16 @@ public class MachineAnnotationServiceUtils {
   }
 
   public static MachineAnnotationServiceRecord givenMasRecord(JsonNode filters) {
+    return givenMasRecord(filters, false);
+  }
+
+  public static MachineAnnotationServiceRecord givenMasRecord(JsonNode filters, boolean batching) {
     return new MachineAnnotationServiceRecord(
         ID,
         1,
         CREATED,
         USER_ID_TOKEN,
-        givenMas(filters),
+        givenMas(filters, batching),
         null
     );
   }
@@ -101,6 +105,10 @@ public class MachineAnnotationServiceUtils {
   }
 
   public static MachineAnnotationService givenMas(JsonNode filters) {
+    return givenMas(filters, false);
+  }
+
+  public static MachineAnnotationService givenMas(JsonNode filters, boolean batching) {
     return new MachineAnnotationService(
         "A Machine Annotation Service",
         "public.ecr.aws/dissco/fancy-mas",
@@ -117,7 +125,7 @@ public class MachineAnnotationServiceUtils {
         "https://www.know.dissco.tech/no_sla",
         "fancy-topic-name",
         5,
-        false
+        batching
     );
   }
 

--- a/src/test/java/eu/dissco/backend/utils/MachineAnnotationServiceUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/MachineAnnotationServiceUtils.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.backend.domain.MachineAnnotationService;
 import eu.dissco.backend.domain.MachineAnnotationServiceRecord;
 import eu.dissco.backend.domain.MasJobRecord;
+import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
@@ -53,9 +54,20 @@ public class MachineAnnotationServiceUtils {
   }
 
   public static JsonApiRequestWrapper givenMasRequest(String type) {
-    var mass = Map.of("mass", List.of(ID));
+    var mass = Map.of("mass", List.of(givenMasJobRequest()));
     var apiRequest = new JsonApiRequest(type, MAPPER.valueToTree(mass));
     return new JsonApiRequestWrapper(apiRequest);
+  }
+
+  public static MasJobRequest givenMasJobRequest() {
+    return givenMasJobRequest(false);
+  }
+
+  public static MasJobRequest givenMasJobRequest(boolean batching) {
+    return new MasJobRequest(
+        ID,
+        batching
+    );
   }
 
   public static MachineAnnotationServiceRecord givenMasRecord() {

--- a/src/test/java/eu/dissco/backend/utils/MasJobRecordUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/MasJobRecordUtils.java
@@ -25,9 +25,12 @@ public class MasJobRecordUtils {
   public static final String MJR_URI = "/api/v1/mjr/";
 
 
-  public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId) {
+  public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId){
+    return givenMasJobRecordIdMap(masId, false);
+  }
+  public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId, boolean batching) {
     var jobIdMap = new HashMap<String, MasJobRecord>();
-    jobIdMap.put(masId, givenMasJobRecord());
+    jobIdMap.put(masId, givenMasJobRecord(batching));
     return jobIdMap;
   }
 
@@ -71,6 +74,10 @@ public class MasJobRecordUtils {
   }
 
   public static MasJobRecord givenMasJobRecord(){
+    return givenMasJobRecord(false);
+  }
+
+  public static MasJobRecord givenMasJobRecord(boolean batching){
     return new MasJobRecord(
         JOB_ID,
         MjrJobState.SCHEDULED,
@@ -78,7 +85,7 @@ public class MasJobRecordUtils {
         ID_ALT,
         MjrTargetType.DIGITAL_SPECIMEN,
         ORCID,
-        false
+        batching
     );
   }
 


### PR DESCRIPTION
Created a MasJobRequest object which has the id and the batching attributes of the request for a MAS.
This also creates the possibility to add more attributes in the future.