### PR TITLE
Don't let trivy break main pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,7 @@ jobs:
       - name: Trivy - Stop on Severe Vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
+          push: ${{ github.event_name == 'pull_request' }}
           image-ref: '${{ github.event.repository.name }}'
           format: 'table'
           ignore-unfixed: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Trivy - Stop on Severe Vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
-          push: ${{ github.event_name == 'pull_request' }}
+          if: ${{ github.event_name == 'pull_request' }}
           image-ref: '${{ github.event.repository.name }}'
           format: 'table'
           ignore-unfixed: true


### PR DESCRIPTION
Only apply task "Trivy - Stop on Severe Vulnerabilities" during PR event. 