### PR TITLE
Batching Conflict exception should be distinct

### DIFF
--- a/src/main/java/eu/dissco/backend/exceptions/BatchingNotPermittedException.java
+++ b/src/main/java/eu/dissco/backend/exceptions/BatchingNotPermittedException.java
@@ -1,0 +1,5 @@
+package eu.dissco.backend.exceptions;
+
+public class BatchingNotPermittedException extends ConflictException {
+
+}

--- a/src/main/java/eu/dissco/backend/service/MachineAnnotationServiceService.java
+++ b/src/main/java/eu/dissco/backend/service/MachineAnnotationServiceService.java
@@ -15,6 +15,7 @@ import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiMeta;
+import eu.dissco.backend.exceptions.BatchingNotPermittedException;
 import eu.dissco.backend.exceptions.ConflictException;
 import eu.dissco.backend.repository.MachineAnnotationServiceRepository;
 import java.util.ArrayList;
@@ -126,7 +127,7 @@ public class MachineAnnotationServiceService {
         log.error(
             "User is attempting to schedule batch annotations with a mas that does not allow this. MAS id: {}",
             masRecord.id());
-        throw new ConflictException();
+        throw new BatchingNotPermittedException();
       }
     }
   }

--- a/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
@@ -17,7 +17,7 @@ import static eu.dissco.backend.utils.MasJobRecordUtils.givenMasJobRecord;
 import static eu.dissco.backend.utils.MasJobRecordUtils.givenMasJobRecordIdMap;
 import static eu.dissco.backend.utils.SpecimenUtils.SPECIMEN_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
@@ -29,6 +29,7 @@ import eu.dissco.backend.domain.MasTarget;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
 import eu.dissco.backend.domain.jsonapi.JsonApiMeta;
+import eu.dissco.backend.exceptions.BatchingNotPermittedException;
 import eu.dissco.backend.exceptions.ConflictException;
 import eu.dissco.backend.repository.MachineAnnotationServiceRepository;
 import java.util.Collections;
@@ -163,7 +164,7 @@ class MachineAnnotationServiceServiceTest {
     given(repository.getMasRecords(Set.of(ID))).willReturn(List.of(masRecord));
 
     // Then
-    assertThrows(ConflictException.class,
+    assertThrowsExactly(BatchingNotPermittedException.class,
         () -> service.scheduleMass(givenFlattenedDigitalSpecimen(),
             Map.of(ID, givenMasJobRequest(true, null)), SPECIMEN_PATH,
             digitalSpecimen, digitalSpecimen.digitalSpecimen().getOdsId(), ORCID,


### PR DESCRIPTION
BatchingNotPermittedException thrown now instead of generic ConflictException when user requests batching on a service that doesn't permit it. 

[Jira](https://naturalis.atlassian.net/browse/DD-1191?atlOrigin=eyJpIjoiYTM4MmY3NDk4YTlmNGY0MDkyYThjMWI2MjVhY2JkZTYiLCJwIjoiaiJ9)