### PR TITLE
Bug fix/fix batch annotations

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -132,7 +132,7 @@ public class AnnotationController extends BaseController {
     schemaValidator.validateAnnotationEventRequest(event, true);
     var userId = authentication.getName();
     log.info("Received new batch annotation from user: {}", userId);
-    var annotationResponse = service.persistAnnotation(event, userId, getPath(request));
+    var annotationResponse = service.persistAnnotationBatch(event, userId, getPath(request));
     if (annotationResponse != null) {
       return ResponseEntity.status(HttpStatus.CREATED).body(annotationResponse);
     } else {

--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -116,7 +116,7 @@ public class AnnotationController extends BaseController {
   @PreAuthorize("hasRole('dissco-web-batch-annotations')")
   @ResponseStatus(HttpStatus.OK)
   @GetMapping(value = "/batch", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonNode> getCountForBatchAnnotations(JsonNode request) throws IOException {
+  public ResponseEntity<JsonNode> getCountForBatchAnnotations(@RequestBody JsonNode request) throws IOException {
     log.info("Received request for batch annotation count");
     var result = service.getCountForBatchAnnotations(request);
     return ResponseEntity.ok(result);

--- a/src/main/java/eu/dissco/backend/domain/MasJobRecord.java
+++ b/src/main/java/eu/dissco/backend/domain/MasJobRecord.java
@@ -11,6 +11,6 @@ public record MasJobRecord(
     MjrTargetType targetType,
     String orcid,
     boolean batchingRequested,
-    Long timeToLive) {
+    Integer timeToLive) {
 
 }

--- a/src/main/java/eu/dissco/backend/domain/MasJobRecordFull.java
+++ b/src/main/java/eu/dissco/backend/domain/MasJobRecordFull.java
@@ -17,7 +17,7 @@ public record MasJobRecordFull(
     Instant timeCompleted,
     JsonNode annotations,
     boolean batchingRequested,
-    Long timeToLive,
+    Integer timeToLive,
     ErrorCode errorCode) {
 
 }

--- a/src/main/java/eu/dissco/backend/domain/annotation/AnnotationTargetType.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/AnnotationTargetType.java
@@ -2,12 +2,14 @@ package eu.dissco.backend.domain.annotation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public enum AnnotationTargetType {
 
   @JsonProperty("https://doi.org/21.T11148/894b1e6cad57e921764e") DIGITAL_SPECIMEN(
       "https://doi.org/21.T11148/894b1e6cad57e921764e"),
-  @JsonProperty("https://doi.org21.T11148/bbad8c4e101e8af01115") MEDIA_OBJECT(
+  @JsonProperty("https://doi.org21.T11148/bbad8c4e101e8af01115") DIGITAL_MEDIA(
       "https://doi.org21.T11148/bbad8c4e101e8af01115");
 
   @Getter
@@ -15,6 +17,17 @@ public enum AnnotationTargetType {
 
   AnnotationTargetType(String name) {
     this.name = name;
+  }
+
+  public static AnnotationTargetType fromString(String type){
+    if (DIGITAL_SPECIMEN.getName().equals(type)){
+      return DIGITAL_SPECIMEN;
+    }
+    if (DIGITAL_MEDIA.getName().equals(type)){
+      return DIGITAL_MEDIA;
+    }
+    log.error("Invalid annotation target type {}", type);
+    throw new IllegalStateException();
   }
 
 }

--- a/src/main/java/eu/dissco/backend/domain/annotation/batch/AnnotationEvent.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/batch/AnnotationEvent.java
@@ -1,9 +1,10 @@
 package eu.dissco.backend.domain.annotation.batch;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import eu.dissco.backend.schema.Annotation;
 import java.util.List;
 
-public record AnnotationEvent(List<Annotation> annotationRequests,
-                              List<BatchMetadata> batchMetadata) {
+public record AnnotationEvent(@JsonProperty("annotations") List<Annotation> annotationRequests,
+                              List<BatchMetadata> batchMetadata, String jobId) {
 
 }

--- a/src/main/java/eu/dissco/backend/domain/annotation/batch/BatchMetadata.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/batch/BatchMetadata.java
@@ -7,7 +7,7 @@ import lombok.Value;
 
 @Value
 public class BatchMetadata {
-  static Integer placeInBatch = 1;
+  Integer placeInBatch = 1;
   @JsonProperty("searchParams")
   List<SearchParam> searchParams;
 

--- a/src/main/java/eu/dissco/backend/repository/MasJobRecordRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/MasJobRecordRepository.java
@@ -138,7 +138,7 @@ public class MasJobRecordRepository {
           dbRecord.get(MAS_JOB_RECORD.TIME_COMPLETED),
           dataNode,
           dbRecord.get(MAS_JOB_RECORD.BATCHING_REQUESTED),
-          ttl,
+          Math.toIntExact(ttl),
           dbRecord.get(MAS_JOB_RECORD.ERROR)
       );
     } catch (JsonProcessingException e) {

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -90,7 +90,7 @@ public class AnnotationService {
     return formatResponse(response, path);
   }
 
-  public JsonApiWrapper persistAnnotation(AnnotationEventRequest eventRequest, String userId,
+  public JsonApiWrapper persistAnnotationBatch(AnnotationEventRequest eventRequest, String userId,
       String path)
       throws ForbiddenException, JsonProcessingException {
     var user = getUserInformation(userId);

--- a/src/main/java/eu/dissco/backend/service/MasJobRecordService.java
+++ b/src/main/java/eu/dissco/backend/service/MasJobRecordService.java
@@ -34,7 +34,7 @@ public class MasJobRecordService {
   private final MasJobRecordRepository masJobRecordRepository;
   private final HandleComponent handleComponent;
   private final ObjectMapper mapper;
-  private final static Long TTL = 86400L; // todo make property
+  private static final Integer TTL = 86400;
 
   public JsonApiWrapper getMasJobRecordById(String masJobRecordHandle, String path)
       throws NotFoundException {
@@ -104,7 +104,6 @@ public class MasJobRecordService {
     var masJobRecordList = masRecords.stream()
         .map(masRecord -> {
           var request = masRequests.get(masRecord.getId());
-          Long ttl = request.timeToLive() == null ? TTL : request.timeToLive();
           return new MasJobRecord(
               handleItr.next(),
               JobState.SCHEDULED,
@@ -113,7 +112,7 @@ public class MasJobRecordService {
               targetType,
               orcid,
               request.batching(),
-              ttl
+              masRecord.getOdsTimeToLive()
           );
         })
         .toList();

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -164,7 +164,7 @@ class AnnotationControllerTest {
     var event = givenAnnotationEventRequest();
     var request = givenJsonApiAnnotationRequest(event);
     var expectedResponse = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH);
-    given(service.persistAnnotation(event, USER_ID_TOKEN, ANNOTATION_PATH))
+    given(service.persistAnnotationBatch(event, USER_ID_TOKEN, ANNOTATION_PATH))
         .willReturn(expectedResponse);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 
@@ -197,7 +197,7 @@ class AnnotationControllerTest {
     givenAuthentication(USER_ID_TOKEN);
     var event = givenAnnotationEventRequest();
     var request = givenJsonApiAnnotationRequest(event);
-    given(service.persistAnnotation(event, USER_ID_TOKEN, ANNOTATION_PATH))
+    given(service.persistAnnotationBatch(event, USER_ID_TOKEN, ANNOTATION_PATH))
         .willReturn(null);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -289,7 +289,7 @@ class AnnotationServiceTest {
   }
 
   @Test
-  void testPersistAnnotation() throws Exception {
+  void testPersistAnnotationBatch() throws Exception {
     // Given
     var annotationRequest = givenAnnotationRequest();
     var processingResponse = MAPPER.valueToTree(givenAnnotationResponse());
@@ -367,7 +367,7 @@ class AnnotationServiceTest {
   }
 
   @Test
-  void testPersistAnnotationBatch() throws Exception {
+  void testPersistAnnotationBatchBatch() throws Exception {
     // Given
     var event = givenAnnotationEventRequest();
     var processingResponse = MAPPER.valueToTree(givenAnnotationResponse().withOdsPlaceInBatch(1));
@@ -377,7 +377,7 @@ class AnnotationServiceTest {
     given(userService.getUser(USER_ID_TOKEN)).willReturn(givenUser());
 
     //When
-    var responseReceived = service.persistAnnotation(event, USER_ID_TOKEN,
+    var responseReceived = service.persistAnnotationBatch(event, USER_ID_TOKEN,
         ANNOTATION_PATH);
 
     // Then
@@ -386,7 +386,7 @@ class AnnotationServiceTest {
   }
 
   @Test
-  void testPersistAnnotationIsNull() throws Exception {
+  void testPersistAnnotationBatchIsNull() throws Exception {
     // Given
     var annotationRequest = givenAnnotationRequest();
     given(annotationClient.postAnnotation(any()))

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -82,6 +82,9 @@ class AnnotationServiceTest {
   private MongoRepository mongoRepository;
   @Mock
   private UserService userService;
+  @Mock
+  private MasJobRecordService masJobRecordService;
+
 
   private MockedStatic<Instant> mockedInstant;
   private MockedStatic<Clock> mockedClock;
@@ -130,7 +133,7 @@ class AnnotationServiceTest {
   @BeforeEach
   void setup() {
     service = new AnnotationService(repository, annotationClient, elasticRepository,
-        mongoRepository, userService, MAPPER);
+        mongoRepository, userService, MAPPER, masJobRecordService);
     Clock clock = Clock.fixed(CREATED, ZoneOffset.UTC);
     Instant instant = Instant.now(clock);
     mockedInstant = mockStatic(Instant.class);
@@ -339,7 +342,8 @@ class AnnotationServiceTest {
                     "inputField": "ods:hasEvent.ods:Location.dwc:country.keyword",
                     "inputValue": "Netherlands"
                   }
-                ]
+                ],
+                "placeInBatch":1
               }
             }
           }

--- a/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MachineAnnotationServiceServiceTest.java
@@ -14,7 +14,6 @@ import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobR
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenScheduledMasResponse;
 import static eu.dissco.backend.utils.MasJobRecordUtils.JOB_ID;
-import static eu.dissco.backend.utils.MasJobRecordUtils.TTL_DEFAULT;
 import static eu.dissco.backend.utils.MasJobRecordUtils.givenMasJobRecord;
 import static eu.dissco.backend.utils.MasJobRecordUtils.givenMasJobRecordIdMap;
 import static eu.dissco.backend.utils.SpecimenUtils.SPECIMEN_PATH;
@@ -121,7 +120,7 @@ class MachineAnnotationServiceServiceTest {
     given(masJobRecordService.createMasJobRecord(Set.of(masRecord), HANDLE + ID, ORCID,
         MjrTargetType.DIGITAL_SPECIMEN,
         Map.of(HANDLE + ID, givenMasJobRequest(true, null)))).willReturn(
-        givenMasJobRecordIdMap(masRecord.getId(), true, TTL_DEFAULT));
+        givenMasJobRecordIdMap(masRecord.getId(), true));
     var sendObject = new MasTarget(digitalSpecimen, JOB_ID, true);
 
     // When
@@ -132,7 +131,7 @@ class MachineAnnotationServiceServiceTest {
 
     // Then
     assertThat(result).isEqualTo(
-        givenScheduledMasResponse(givenMasJobRecord(true, TTL_DEFAULT), SPECIMEN_PATH));
+        givenScheduledMasResponse(givenMasJobRecord(true), SPECIMEN_PATH));
     then(kafkaPublisherService).should().sendObjectToQueue("fancy-topic-name", sendObject);
   }
 

--- a/src/test/java/eu/dissco/backend/service/MasJobRecordServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/MasJobRecordServiceTest.java
@@ -193,7 +193,7 @@ class MasJobRecordServiceTest {
     // Given
     var ttl = 3600L;
     var masRecord = MachineAnnotationServiceUtils.givenMas();
-    var expected = givenMasJobRecordIdMap(masRecord.getId(), ttl);
+    var expected = givenMasJobRecordIdMap(masRecord.getId());
     given(handleComponent.postHandle(1)).willReturn(List.of(JOB_ID));
 
     // When

--- a/src/test/java/eu/dissco/backend/utils/AnnotationUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/AnnotationUtils.java
@@ -229,7 +229,7 @@ public class AnnotationUtils {
 
   public static AnnotationEvent givenAnnotationEventProcessed() {
     return new AnnotationEvent(List.of(givenAnnotationProcessingRequest(false)),
-        List.of(new BatchMetadata(List.of(givenSearchParam()))));
+        List.of(new BatchMetadata(List.of(givenSearchParam()))), null);
   }
 
   public static BatchMetadata givenBatchMetadata() {

--- a/src/test/java/eu/dissco/backend/utils/MachineAnnotationServiceUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/MachineAnnotationServiceUtils.java
@@ -5,6 +5,7 @@ import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.MAS_ID;
 import static eu.dissco.backend.TestUtils.ORCID;
+import static eu.dissco.backend.utils.MasJobRecordUtils.TTL_DEFAULT;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -87,7 +88,7 @@ public class MachineAnnotationServiceUtils {
         deleted,
         new OdsTargetDigitalObjectFilter(),
         false,
-        3600
+        TTL_DEFAULT
     );
   }
 
@@ -98,7 +99,7 @@ public class MachineAnnotationServiceUtils {
         null,
         filters,
         batching,
-        3600
+        TTL_DEFAULT
     );
   }
 

--- a/src/test/java/eu/dissco/backend/utils/MasJobRecordUtils.java
+++ b/src/test/java/eu/dissco/backend/utils/MasJobRecordUtils.java
@@ -23,21 +23,16 @@ public class MasJobRecordUtils {
   public static final String JOB_SUFFIX = "TR9-6D6-Z4A";
   public static final String JOB_ID_ALT = "20.5000.1025/P3D-22A-MRY";
   public static final String MJR_URI = "/api/v1/mjr/";
-  public static Long TTL_DEFAULT = 86400L;
+  public static final Integer TTL_DEFAULT = 86400;
 
 
   public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId) {
-    return givenMasJobRecordIdMap(masId, false, TTL_DEFAULT);
+    return givenMasJobRecordIdMap(masId, false);
   }
 
-  public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId, long ttl) {
-    return givenMasJobRecordIdMap(masId, false, ttl);
-  }
-
-  public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId, boolean batching,
-      Long ttl) {
+  public static Map<String, MasJobRecord> givenMasJobRecordIdMap(String masId, boolean batching) {
     var jobIdMap = new HashMap<String, MasJobRecord>();
-    jobIdMap.put(masId, givenMasJobRecord(batching, ttl));
+    jobIdMap.put(masId, givenMasJobRecord(batching));
     return jobIdMap;
   }
 
@@ -85,10 +80,10 @@ public class MasJobRecordUtils {
   }
 
   public static MasJobRecord givenMasJobRecord() {
-    return givenMasJobRecord(false, TTL_DEFAULT);
+    return givenMasJobRecord(false);
   }
 
-  public static MasJobRecord givenMasJobRecord(boolean batching, Long ttl) {
+  public static MasJobRecord givenMasJobRecord(boolean batching) {
     return new MasJobRecord(
         JOB_ID,
         JobState.SCHEDULED,
@@ -97,7 +92,7 @@ public class MasJobRecordUtils {
         MjrTargetType.DIGITAL_SPECIMEN,
         ORCID,
         batching,
-        ttl
+        TTL_DEFAULT
     );
   }
 


### PR DESCRIPTION
Fixes
- Assigns web batch requests job information in the masJobRecord table. The processing service expects batch results to have an entry in this table. May want to rename this to "scheduledJobRecords" down the line
- media object -> digital media