### PR TITLE
Include annotation and agent in archive request

### DIFF
--- a/src/main/java/eu/dissco/backend/client/AnnotationClient.java
+++ b/src/main/java/eu/dissco/backend/client/AnnotationClient.java
@@ -3,6 +3,7 @@ package eu.dissco.backend.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.backend.domain.annotation.batch.AnnotationEvent;
+import eu.dissco.backend.schema.Agent;
 import eu.dissco.backend.schema.Annotation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,6 +26,6 @@ public interface AnnotationClient {
       @PathVariable("suffix") String suffix, @RequestBody Annotation annotation);
 
   @DeleteMapping(value = "/{prefix}/{suffix}")
-  void deleteAnnotation(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix);
+  void tombstoneAnnotation(@PathVariable("prefix") String prefix,
+      @PathVariable("suffix") String suffix, Annotation annotation, Agent tombstoningAgent);
 }

--- a/src/main/java/eu/dissco/backend/client/AnnotationClient.java
+++ b/src/main/java/eu/dissco/backend/client/AnnotationClient.java
@@ -2,8 +2,8 @@ package eu.dissco.backend.client;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.backend.domain.annotation.AnnotationTombstoneWrapper;
 import eu.dissco.backend.domain.annotation.batch.AnnotationEvent;
-import eu.dissco.backend.schema.Agent;
 import eu.dissco.backend.schema.Annotation;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,5 +27,5 @@ public interface AnnotationClient {
 
   @DeleteMapping(value = "/{prefix}/{suffix}")
   void tombstoneAnnotation(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix, Annotation annotation, Agent tombstoningAgent);
+      @PathVariable("suffix") String suffix, @RequestBody AnnotationTombstoneWrapper annotationTombstoneWrapper);
 }

--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -103,9 +103,9 @@ public class AnnotationController extends BaseController {
       @RequestBody JsonApiRequestWrapper requestBody, HttpServletRequest request)
       throws JsonProcessingException, ForbiddenException {
     var annotation = getAnnotationFromRequest(requestBody);
-    var user = getUser(authentication);
-    log.info("Received new annotationRequests from user: {}", user.orcid());
-    var annotationResponse = service.persistAnnotation(annotation, user, getPath(request));
+    var agent = getAgent(authentication);
+    log.info("Received new annotationRequests from agent: {}", agent.getId());
+    var annotationResponse = service.persistAnnotation(annotation, agent, getPath(request));
     if (annotationResponse != null) {
       return ResponseEntity.status(HttpStatus.CREATED).body(annotationResponse);
     } else {
@@ -130,7 +130,7 @@ public class AnnotationController extends BaseController {
       throws JsonProcessingException, ForbiddenException, InvalidAnnotationRequestException {
     var event = getAnnotationFromRequestEvent(requestBody);
     schemaValidator.validateAnnotationEventRequest(event, true);
-    var user = getUser(authentication);
+    var user = getAgent(authentication);
     log.info("Received new batch annotation from user: {}", user);
     var annotationResponse = service.persistAnnotationBatch(event, user, getPath(request));
     if (annotationResponse != null) {
@@ -147,10 +147,10 @@ public class AnnotationController extends BaseController {
       @PathVariable("suffix") String suffix, HttpServletRequest request)
       throws NoAnnotationFoundException, JsonProcessingException, ForbiddenException {
     var id = prefix + '/' + suffix;
-    var user = getUser(authentication);
+    var agent = getAgent(authentication);
     var annotation = getAnnotationFromRequest(requestBody);
-    log.info("Received update for annotationRequests: {} from user: {}", id, user.orcid());
-    var annotationResponse = service.updateAnnotation(id, annotation, user, getPath(request),
+    log.info("Received update for annotationRequests: {} from user: {}", id, agent.getId());
+    var annotationResponse = service.updateAnnotation(id, annotation, agent, getPath(request),
         prefix, suffix);
     if (annotationResponse != null) {
       return ResponseEntity.status(HttpStatus.OK).body(annotationResponse);
@@ -166,7 +166,7 @@ public class AnnotationController extends BaseController {
       @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
       @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize, HttpServletRequest request,
       Authentication authentication) throws IOException, ForbiddenException {
-    var orcid = getUser(authentication).orcid();
+    var orcid = getAgent(authentication).getId();
     log.info("Received get request to show all annotationRequests for user: {}", orcid);
     var annotations = service.getAnnotationsForUser(orcid, pageNumber, pageSize,
         getPath(request));
@@ -186,12 +186,12 @@ public class AnnotationController extends BaseController {
   @PreAuthorize("isAuthenticated()")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @DeleteMapping(value = "/{prefix}/{suffix}")
-  public ResponseEntity<Void> deleteAnnotation(Authentication authentication,
+  public ResponseEntity<Void> tombstoneAnnotation(Authentication authentication,
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
       throws NoAnnotationFoundException, ForbiddenException {
-    var orcid = getUser(authentication).orcid();
-    log.info("Received delete for annotationRequests: {} from user: {}", (prefix + suffix), orcid);
-    var success = service.deleteAnnotation(prefix, suffix, orcid);
+    var agent = getAgent(authentication);
+    log.info("Received delete for annotationRequests: {} from user: {}", (prefix + suffix), agent.getId());
+    var success = service.tombstoneAnnotation(prefix, suffix, agent);
     if (success) {
       return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     } else {

--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -183,7 +183,6 @@ public class AnnotationController extends BaseController {
     return ResponseEntity.ok(versions);
   }
 
-  @PreAuthorize("isAuthenticated()")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @DeleteMapping(value = "/{prefix}/{suffix}")
   public ResponseEntity<Void> tombstoneAnnotation(Authentication authentication,

--- a/src/main/java/eu/dissco/backend/controller/BaseController.java
+++ b/src/main/java/eu/dissco/backend/controller/BaseController.java
@@ -1,17 +1,15 @@
 package eu.dissco.backend.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.domain.MasJobRequest;
-import eu.dissco.backend.domain.User;
 import eu.dissco.backend.domain.jsonapi.JsonApiRequestWrapper;
 import eu.dissco.backend.exceptions.ConflictException;
 import eu.dissco.backend.exceptions.ForbiddenException;
 import eu.dissco.backend.properties.ApplicationProperties;
+import eu.dissco.backend.schema.Agent;
+import eu.dissco.backend.schema.Agent.Type;
 import jakarta.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -35,9 +33,9 @@ public abstract class BaseController {
   protected final ObjectMapper mapper;
   private final ApplicationProperties applicationProperties;
 
-  protected User getUser(Authentication authentication) throws ForbiddenException {
-    var claims = ((Jwt) authentication.getPrincipal()).getClaims();
 
+  protected Agent getAgent(Authentication authentication) throws ForbiddenException {
+    var claims = ((Jwt) authentication.getPrincipal()).getClaims();
     if (claims.containsKey("orcid")) {
       StringBuilder fullName = new StringBuilder();
       if (claims.containsKey("given_name")){
@@ -49,7 +47,10 @@ public abstract class BaseController {
         }
         fullName.append(claims.get("family_name"));
       }
-      return new User(fullName.toString(), (String) claims.get("orcid"));
+      return new Agent()
+          .withType(Type.SCHEMA_PERSON)
+          .withSchemaName(fullName.toString())
+          .withId((String) claims.get("orcid"));
     } else {
       log.error("Missing ORCID in token");
       throw new ForbiddenException("Missing ORCID in token");

--- a/src/main/java/eu/dissco/backend/controller/DigitalMediaController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalMediaController.java
@@ -133,14 +133,13 @@ public class DigitalMediaController extends BaseController {
     return ResponseEntity.ok(service.getOriginalDataForMedia(id, path));
   }
 
-
   @PostMapping(value = "/{prefix}/{suffix}/mas", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> scheduleMassForDigitalMediaObject(
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @RequestBody JsonApiRequestWrapper requestBody, Authentication authentication,
       HttpServletRequest request)
       throws ConflictException, ForbiddenException, PidCreationException {
-    var orcid = getUser(authentication).orcid();
+    var orcid = getAgent(authentication).getId();
     var id = prefix + '/' + suffix;
     var masRequests = getMassRequestFromRequest(requestBody);
     log.info("Received request to schedule all relevant MASs of: {} on digital media: {}",

--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -234,7 +234,7 @@ public class DigitalSpecimenController extends BaseController {
       @RequestBody JsonApiRequestWrapper requestBody, Authentication authentication,
       HttpServletRequest request)
       throws ConflictException, ForbiddenException, PidCreationException {
-    var orcid = getUser(authentication).orcid();
+    var orcid = getAgent(authentication).getId();
     var id = prefix + '/' + suffix;
     var masRequests = getMassRequestFromRequest(requestBody);
     log.info("Received request to schedule all relevant MASs for: {} on digital specimen: {}",

--- a/src/main/java/eu/dissco/backend/domain/User.java
+++ b/src/main/java/eu/dissco/backend/domain/User.java
@@ -1,8 +1,0 @@
-package eu.dissco.backend.domain;
-
-public record User(
-    String fullName,
-    String orcid
-) {
-
-}

--- a/src/main/java/eu/dissco/backend/domain/annotation/AnnotationTombstoneWrapper.java
+++ b/src/main/java/eu/dissco/backend/domain/annotation/AnnotationTombstoneWrapper.java
@@ -1,0 +1,11 @@
+package eu.dissco.backend.domain.annotation;
+
+import eu.dissco.backend.schema.Agent;
+import eu.dissco.backend.schema.Annotation;
+
+public record AnnotationTombstoneWrapper(
+    Annotation annotation,
+    Agent tombstoningAgent
+) {
+
+}

--- a/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
@@ -40,7 +40,7 @@ public class AnnotationRepository {
         .limit(pageSizePlusOne).offset(offset).fetch(this::mapToAnnotation);
   }
 
-  public Optional<Annotation> getAnnotationForUser(String id, String userId) {
+  public Optional<Annotation> getActiveAnnotationForUser(String id, String userId) {
     return context.select(ANNOTATION.asterisk())
         .from(ANNOTATION)
         .where(ANNOTATION.ID.eq(id))

--- a/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.exceptions.DisscoJsonBMappingException;
 import eu.dissco.backend.schema.Annotation;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -39,13 +40,13 @@ public class AnnotationRepository {
         .limit(pageSizePlusOne).offset(offset).fetch(this::mapToAnnotation);
   }
 
-  public int getAnnotationForUser(String id, String userId) {
-    return context.select(ANNOTATION.ID)
+  public Optional<Annotation> getAnnotationForUser(String id, String userId) {
+    return context.select(ANNOTATION.asterisk())
         .from(ANNOTATION)
         .where(ANNOTATION.ID.eq(id))
         .and(ANNOTATION.CREATOR_ID.eq(userId))
         .and(ANNOTATION.TOMBSTONED_ON.isNull())
-        .fetch().size();
+        .fetchOptional(this::mapToAnnotation);
   }
 
   public List<Annotation> getForTarget(String id) {

--- a/src/main/java/eu/dissco/backend/repository/MachineAnnotationServiceRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/MachineAnnotationServiceRepository.java
@@ -1,6 +1,7 @@
 package eu.dissco.backend.repository;
 
 import static eu.dissco.backend.database.jooq.Tables.MACHINE_ANNOTATION_SERVICE;
+import static eu.dissco.backend.repository.RepositoryUtils.HANDLE_STRING;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,6 +50,6 @@ public class MachineAnnotationServiceRepository {
 
   private String removeProxy(String id) {
     return id.replace("urn:uuid:", "")
-        .replace("https://hdl.handle.net/", "");
+        .replace(HANDLE_STRING, "");
   }
 }

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.client.AnnotationClient;
-import eu.dissco.backend.domain.User;
 import eu.dissco.backend.domain.annotation.AnnotationTargetType;
 import eu.dissco.backend.domain.annotation.batch.AnnotationEvent;
 import eu.dissco.backend.domain.annotation.batch.AnnotationEventRequest;
@@ -23,7 +22,6 @@ import eu.dissco.backend.repository.AnnotationRepository;
 import eu.dissco.backend.repository.ElasticSearchRepository;
 import eu.dissco.backend.repository.MongoRepository;
 import eu.dissco.backend.schema.Agent;
-import eu.dissco.backend.schema.Agent.Type;
 import eu.dissco.backend.schema.Annotation;
 import eu.dissco.backend.schema.Annotation.OaMotivation;
 import eu.dissco.backend.schema.AnnotationProcessingRequest;
@@ -80,20 +78,20 @@ public class AnnotationService {
     return wrapListResponse(annotationsPlusOne, pageNumber, pageSize, path);
   }
 
-  public JsonApiWrapper persistAnnotation(AnnotationProcessingRequest annotationProcessingRequest, User user,
+  public JsonApiWrapper persistAnnotation(AnnotationProcessingRequest annotationProcessingRequest, Agent agent,
       String path) throws JsonProcessingException {
-    var annotation = buildAnnotation(annotationProcessingRequest, user, false);
+    var annotation = buildAnnotation(annotationProcessingRequest, agent, false);
     var response = annotationClient.postAnnotation(annotation);
     return formatResponse(response, path);
   }
 
-  public JsonApiWrapper persistAnnotationBatch(AnnotationEventRequest eventRequest, User user,
+  public JsonApiWrapper persistAnnotationBatch(AnnotationEventRequest eventRequest, Agent agent,
       String path) throws JsonProcessingException {
-    var processedAnnotation = buildAnnotation(eventRequest.annotationRequests().get(0), user, false)
+    var processedAnnotation = buildAnnotation(eventRequest.annotationRequests().get(0), agent, false)
         .withOdsPlaceInBatch(1);
     String jobId = null;
     if (eventRequest.batchMetadata() != null){
-      jobId = masJobRecordService.createJobRecordForDisscover(processedAnnotation, user.orcid());
+      jobId = masJobRecordService.createJobRecordForDisscover(processedAnnotation, agent.getId());
     }
     var processedEvent = new AnnotationEvent(List.of(processedAnnotation),
         eventRequest.batchMetadata(), jobId);
@@ -142,7 +140,7 @@ public class AnnotationService {
     }
   }
 
-  private Annotation buildAnnotation(AnnotationProcessingRequest annotationProcessingRequest, User user,
+  private Annotation buildAnnotation(AnnotationProcessingRequest annotationProcessingRequest, Agent agent,
       boolean isUpdate) {
     var annotation = new Annotation()
         .withOaMotivation(OaMotivation.fromValue(annotationProcessingRequest.getOaMotivation().value()))
@@ -150,10 +148,7 @@ public class AnnotationService {
         .withOaHasBody(annotationProcessingRequest.getOaHasBody())
         .withOaHasTarget(annotationProcessingRequest.getOaHasTarget())
         .withDctermsCreated(Date.from(Instant.now()))
-        .withDctermsCreator(new Agent()
-            .withType(Type.SCHEMA_PERSON)
-            .withId(user.orcid())
-            .withSchemaName(user.fullName()));
+        .withDctermsCreator(agent);
     if (isUpdate) {
       annotation.setId(annotationProcessingRequest.getOdsID());
       annotation.setOdsID(annotationProcessingRequest.getOdsID());
@@ -166,20 +161,20 @@ public class AnnotationService {
   }
 
   public JsonApiWrapper updateAnnotation(String id, AnnotationProcessingRequest annotationProcessingRequest,
-      User user,
+      Agent agent,
       String path, String prefix, String suffix)
       throws NoAnnotationFoundException, JsonProcessingException {
-    var result = repository.getAnnotationForUser(id, user.orcid());
-    if (result > 0) {
+    var result = repository.getAnnotationForUser(id, agent.getId());
+    if (result.isPresent()) {
       if (annotationProcessingRequest.getOdsID() == null) {
         annotationProcessingRequest.setOdsID(id);
       }
-      var annotation = buildAnnotation(annotationProcessingRequest, user, true);
+      var annotation = buildAnnotation(annotationProcessingRequest, agent, true);
       var response = annotationClient.updateAnnotation(prefix, suffix, annotation);
       return formatResponse(response, path);
     } else {
       log.info("No active annotationRequests with id: {} found for user {}", id,
-          user.orcid());
+          agent.getId());
       throw new NoAnnotationFoundException(
           "No active annotationRequests with id: " + id + " was found for user");
     }
@@ -199,15 +194,15 @@ public class AnnotationService {
     return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
   }
 
-  public boolean deleteAnnotation(String prefix, String suffix, String orcid)
+  public boolean tombstoneAnnotation(String prefix, String suffix, Agent agent)
       throws NoAnnotationFoundException {
     var id = prefix + "/" + suffix;
-    var result = repository.getAnnotationForUser(id, orcid);
-    if (result > 0) {
-      annotationClient.deleteAnnotation(prefix, suffix);
+    var result = repository.getAnnotationForUser(id, agent.getId());
+    if (result.isPresent()) {
+      annotationClient.tombstoneAnnotation(prefix, suffix, result.get(), agent);
       return true;
     } else {
-      log.info("No active annotationRequests with id: {} found for user: {}", id, orcid);
+      log.info("No active annotationRequests with id: {} found for user: {}", id, agent.getId());
       throw new NoAnnotationFoundException(
           "No active annotationRequests with id: " + id + " was found for user");
     }

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.client.AnnotationClient;
 import eu.dissco.backend.domain.annotation.AnnotationTargetType;
+import eu.dissco.backend.domain.annotation.AnnotationTombstoneWrapper;
 import eu.dissco.backend.domain.annotation.batch.AnnotationEvent;
 import eu.dissco.backend.domain.annotation.batch.AnnotationEventRequest;
 import eu.dissco.backend.domain.annotation.batch.BatchMetadata;
@@ -164,7 +165,7 @@ public class AnnotationService {
       Agent agent,
       String path, String prefix, String suffix)
       throws NoAnnotationFoundException, JsonProcessingException {
-    var result = repository.getAnnotationForUser(id, agent.getId());
+    var result = repository.getActiveAnnotationForUser(id, agent.getId());
     if (result.isPresent()) {
       if (annotationProcessingRequest.getOdsID() == null) {
         annotationProcessingRequest.setOdsID(id);
@@ -197,9 +198,9 @@ public class AnnotationService {
   public boolean tombstoneAnnotation(String prefix, String suffix, Agent agent)
       throws NoAnnotationFoundException {
     var id = prefix + "/" + suffix;
-    var result = repository.getAnnotationForUser(id, agent.getId());
+    var result = repository.getActiveAnnotationForUser(id, agent.getId());
     if (result.isPresent()) {
-      annotationClient.tombstoneAnnotation(prefix, suffix, result.get(), agent);
+      annotationClient.tombstoneAnnotation(prefix, suffix, new AnnotationTombstoneWrapper(result.get(), agent));
       return true;
     } else {
       log.info("No active annotationRequests with id: {} found for user: {}", id, agent.getId());

--- a/src/test/java/eu/dissco/backend/TestUtils.java
+++ b/src/test/java/eu/dissco/backend/TestUtils.java
@@ -2,8 +2,9 @@ package eu.dissco.backend;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.dissco.backend.domain.User;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
+import eu.dissco.backend.schema.Agent;
+import eu.dissco.backend.schema.Agent.Type;
 import eu.dissco.backend.schema.DigitalSpecimen;
 import eu.dissco.backend.schema.DigitalSpecimen.OdsPhysicalSpecimenIDType;
 import eu.dissco.backend.schema.Event;
@@ -44,9 +45,11 @@ public class TestUtils {
   public static final String DIGITAL_SPECIMEN_TYPE = "https://doi.org/21.T11148/894b1e6cad57e921764e";
 
   // Users
-  public static User givenUser() {
-    return new User("Sam Leeflang", ORCID
-    );
+  public static Agent givenAgent() {
+    return new Agent()
+        .withType(Type.SCHEMA_PERSON)
+        .withSchemaName("Sam Leeflang")
+        .withId(ORCID);
   }
 
   // Token

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -2,12 +2,11 @@ package eu.dissco.backend.controller;
 
 import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
-import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.PREFIX;
 import static eu.dissco.backend.TestUtils.SUFFIX;
 import static eu.dissco.backend.TestUtils.USER_ID_TOKEN;
 import static eu.dissco.backend.TestUtils.givenClaims;
-import static eu.dissco.backend.TestUtils.givenUser;
+import static eu.dissco.backend.TestUtils.givenAgent;
 import static eu.dissco.backend.utils.AnnotationUtils.ANNOTATION_PATH;
 import static eu.dissco.backend.utils.AnnotationUtils.ANNOTATION_URI;
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationCountRequest;
@@ -143,7 +142,7 @@ class AnnotationControllerTest {
 
     var request = givenJsonApiAnnotationRequest(annotation);
     var expectedResponse = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH);
-    given(service.persistAnnotation(annotation, givenUser(), ANNOTATION_PATH))
+    given(service.persistAnnotation(annotation, givenAgent(), ANNOTATION_PATH))
         .willReturn(expectedResponse);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 
@@ -186,7 +185,7 @@ class AnnotationControllerTest {
     var event = givenAnnotationEventRequest();
     var request = givenJsonApiAnnotationRequest(event);
     var expectedResponse = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH);
-    given(service.persistAnnotationBatch(event, givenUser(), ANNOTATION_PATH))
+    given(service.persistAnnotationBatch(event, givenAgent(), ANNOTATION_PATH))
         .willReturn(expectedResponse);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 
@@ -221,7 +220,7 @@ class AnnotationControllerTest {
     givenAuthentication();
     var event = givenAnnotationEventRequest();
     var request = givenJsonApiAnnotationRequest(event);
-    given(service.persistAnnotationBatch(event, givenUser(), ANNOTATION_PATH))
+    given(service.persistAnnotationBatch(event, givenAgent(), ANNOTATION_PATH))
         .willReturn(null);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 
@@ -239,7 +238,7 @@ class AnnotationControllerTest {
     var annotation = givenAnnotationRequest();
     var requestBody = givenJsonApiAnnotationRequest(annotation);
     var expected = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH);
-    given(service.updateAnnotation(ID, annotation, givenUser(), ANNOTATION_PATH, PREFIX,
+    given(service.updateAnnotation(ID, annotation, givenAgent(), ANNOTATION_PATH, PREFIX,
         SUFFIX)).willReturn(
         expected);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
@@ -278,26 +277,26 @@ class AnnotationControllerTest {
   }
 
   @Test
-  void testDeleteAnnotationSuccess() throws Exception {
+  void testTombstoneAnnotationSuccess() throws Exception {
     // Given
     givenAuthentication();
-    given(service.deleteAnnotation(PREFIX, SUFFIX, ORCID)).willReturn(true);
+    given(service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent())).willReturn(true);
 
     // When
-    var receivedResponse = controller.deleteAnnotation(authentication, PREFIX, SUFFIX);
+    var receivedResponse = controller.tombstoneAnnotation(authentication, PREFIX, SUFFIX);
 
     // Then
     assertThat(receivedResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
   @Test
-  void testDeleteAnnotationFailure() throws Exception {
+  void testTombstoneAnnotationFailure() throws Exception {
     // Given
     givenAuthentication();
-    given(service.deleteAnnotation(PREFIX, SUFFIX, ORCID)).willReturn(false);
+    given(service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent())).willReturn(false);
 
     // When
-    var receivedResponse = controller.deleteAnnotation(authentication, PREFIX, SUFFIX);
+    var receivedResponse = controller.tombstoneAnnotation(authentication, PREFIX, SUFFIX);
 
     // Then
     assertThat(receivedResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);

--- a/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
@@ -76,7 +76,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetAnnotationForUser() throws JsonProcessingException {
+  void testGetActiveAnnotationForUser() throws JsonProcessingException {
     // Given
     var annotations = List.of(givenAnnotationResponse(ID),
         givenAnnotationResponse(USER_ID_TOKEN, "AnotherUser", PREFIX + "/TAR-GET-002"),
@@ -84,7 +84,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     postAnnotations(annotations);
 
     // When
-    var receivedResponse = repository.getAnnotationForUser(ID, ORCID);
+    var receivedResponse = repository.getActiveAnnotationForUser(ID, ORCID);
 
     // Then
     assertThat(receivedResponse).isEqualTo(Optional.of(annotations.get(0)));

--- a/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
@@ -18,6 +18,7 @@ import eu.dissco.backend.exceptions.DisscoJsonBMappingException;
 import eu.dissco.backend.schema.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import org.jooq.JSONB;
 import org.jooq.Query;
@@ -86,7 +87,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     var receivedResponse = repository.getAnnotationForUser(ID, ORCID);
 
     // Then
-    assertThat(receivedResponse).isEqualTo(1);
+    assertThat(receivedResponse).isEqualTo(Optional.of(annotations.get(0)));
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -407,7 +407,7 @@ class AnnotationServiceTest {
   void testUpdateAnnotation() throws Exception {
     // Given
     var expected = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH, ORCID);
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
     var kafkaResponse = MAPPER.valueToTree(givenAnnotationResponse());
     given(annotationClient.updateAnnotation(any(), any(), any()))
         .willReturn(kafkaResponse);
@@ -424,7 +424,7 @@ class AnnotationServiceTest {
   @Test
   void testUpdateAnnotationDoesNotExist() {
     // Given
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
+    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,
@@ -475,7 +475,7 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotation() throws Exception {
     // Given
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
 
     // When
     var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent());
@@ -487,7 +487,7 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotationDoesNotExist() {
     // Given
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
+    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -8,7 +8,7 @@ import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.PREFIX;
 import static eu.dissco.backend.TestUtils.SANDBOX_URI;
 import static eu.dissco.backend.TestUtils.SUFFIX;
-import static eu.dissco.backend.TestUtils.givenUser;
+import static eu.dissco.backend.TestUtils.givenAgent;
 import static eu.dissco.backend.controller.BaseController.DATE_STRING;
 import static eu.dissco.backend.utils.AnnotationUtils.ANNOTATION_PATH;
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationCountRequest;
@@ -49,6 +49,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.errors.InvalidRequestException;
@@ -290,7 +291,7 @@ class AnnotationServiceTest {
         processingResponse);
 
     //When
-    var responseReceived = service.persistAnnotation(annotationRequest, givenUser(),
+    var responseReceived = service.persistAnnotation(annotationRequest, givenAgent(),
         ANNOTATION_PATH);
 
     // Then
@@ -367,7 +368,7 @@ class AnnotationServiceTest {
         processingResponse);
 
     //When
-    var responseReceived = service.persistAnnotationBatch(event, givenUser(),
+    var responseReceived = service.persistAnnotationBatch(event, givenAgent(),
         ANNOTATION_PATH);
 
     // Then
@@ -383,7 +384,7 @@ class AnnotationServiceTest {
         .willReturn(null);
 
     // When
-    var result = service.persistAnnotation(annotationRequest, givenUser(), ANNOTATION_PATH
+    var result = service.persistAnnotation(annotationRequest, givenAgent(), ANNOTATION_PATH
     );
 
     // Then
@@ -406,13 +407,13 @@ class AnnotationServiceTest {
   void testUpdateAnnotation() throws Exception {
     // Given
     var expected = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH, ORCID);
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(1);
+    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
     var kafkaResponse = MAPPER.valueToTree(givenAnnotationResponse());
     given(annotationClient.updateAnnotation(any(), any(), any()))
         .willReturn(kafkaResponse);
 
     // When
-    var result = service.updateAnnotation(ID, givenAnnotationRequest(), givenUser(),
+    var result = service.updateAnnotation(ID, givenAnnotationRequest(), givenAgent(),
         ANNOTATION_PATH,
         PREFIX, SUFFIX);
 
@@ -423,11 +424,11 @@ class AnnotationServiceTest {
   @Test
   void testUpdateAnnotationDoesNotExist() {
     // Given
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(0);
+    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,
-        () -> service.updateAnnotation(ID, givenAnnotationRequest(), givenUser(),
+        () -> service.updateAnnotation(ID, givenAnnotationRequest(), givenAgent(),
             ANNOTATION_PATH, PREFIX, SUFFIX));
   }
 
@@ -472,25 +473,25 @@ class AnnotationServiceTest {
   }
 
   @Test
-  void testDeleteAnnotation() throws Exception {
+  void testTombstoneAnnotation() throws Exception {
     // Given
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(1);
+    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
 
     // When
-    var result = service.deleteAnnotation(PREFIX, SUFFIX, ORCID);
+    var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent());
 
     // Then
     assertThat(result).isTrue();
   }
 
   @Test
-  void testDeleteAnnotationDoesNotExist() {
+  void testTombstoneAnnotationDoesNotExist() {
     // Given
-    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(0);
+    given(repository.getAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,
-        () -> service.deleteAnnotation(PREFIX, SUFFIX, ORCID));
+        () -> service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent()));
   }
 
 }


### PR DESCRIPTION
Sends Annotation and Tombstoning Agent to annotation processing service on archive request
- We need to update the annotation data in the processing service to include tombstone metadata -> we need the resolved annotation to do this
- We need the tombstoning agent in the tombstone metadata
- The backend already has code to resolve annotations and extract agents from tokens, would be a redundant code in the processing service to resolve the annotation. besides, we already did a database call to check if the annotation exists, so performance isn't impacted, i just repurposed that call to provide more information

Other changes
- `getUser()` -> `getAgent()` from token, `User` object is obsolete
