### PR TITLE
Add proxies to ids passed to mongodb

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -1,5 +1,7 @@
 package eu.dissco.backend.controller;
 
+import static eu.dissco.backend.repository.RepositoryUtils.HANDLE_STRING;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -80,7 +82,7 @@ public class AnnotationController extends BaseController {
       @PathVariable("suffix") String suffix, @PathVariable("version") int version,
       HttpServletRequest request)
       throws JsonProcessingException, NotFoundException {
-    var id = prefix + '/' + suffix;
+    var id = HANDLE_STRING + prefix + '/' + suffix;
     log.info("Received get request for annotationRequests: {} with version: {}", id, version);
     var annotation = service.getAnnotationByVersion(id, version, getPath(request));
     return ResponseEntity.ok(annotation);
@@ -177,7 +179,7 @@ public class AnnotationController extends BaseController {
   @GetMapping(value = "/{prefix}/{suffix}/versions", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> getAnnotationVersions(@PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, HttpServletRequest request) throws NotFoundException {
-    var id = prefix + '/' + suffix;
+    var id = HANDLE_STRING + prefix + '/' + suffix;
     log.info("Received get request for versions of annotationRequests with id: {}", id);
     var versions = service.getAnnotationVersions(id, getPath(request));
     return ResponseEntity.ok(versions);

--- a/src/main/java/eu/dissco/backend/controller/DigitalMediaController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalMediaController.java
@@ -1,6 +1,8 @@
 package eu.dissco.backend.controller;
 
 
+import static eu.dissco.backend.repository.RepositoryUtils.DOI_STRING;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.database.jooq.enums.JobState;
@@ -81,7 +83,7 @@ public class DigitalMediaController extends BaseController {
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       HttpServletRequest request)
       throws NotFoundException {
-    var id = prefix + '/' + suffix;
+    var id = DOI_STRING + prefix + '/' + suffix;
     log.info("Received get request for versions of digital media with id: {}", id);
     var versions = service.getDigitalMediaVersions(id, getPath(request));
     return ResponseEntity.ok(versions);
@@ -92,7 +94,7 @@ public class DigitalMediaController extends BaseController {
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix,
       @PathVariable("version") int version, HttpServletRequest request)
       throws JsonProcessingException, NotFoundException {
-    var id = prefix + '/' + suffix;
+    var id = DOI_STRING + prefix + '/' + suffix;
     log.info("Received get request for digital media: {} with version: {}", id, version);
     var digitalMedia = service.getDigitalMediaObjectByVersion(id, version, getPath(request));
     return ResponseEntity.ok(digitalMedia);

--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -1,5 +1,7 @@
 package eu.dissco.backend.controller;
 
+import static eu.dissco.backend.repository.RepositoryUtils.DOI_STRING;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.database.jooq.enums.JobState;
@@ -93,7 +95,7 @@ public class DigitalSpecimenController extends BaseController {
       @PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, @PathVariable("version") int version,
       HttpServletRequest request) throws NotFoundException, JsonProcessingException {
-    var id = prefix + '/' + suffix;
+    var id = DOI_STRING + prefix + '/' + suffix;
     log.info("Received get request for full specimen with id: {} and version: {}", id, version);
     var specimen = service.getSpecimenByVersionFull(id, version, getPath(request));
     return ResponseEntity.ok(specimen);
@@ -105,7 +107,7 @@ public class DigitalSpecimenController extends BaseController {
       @PathVariable("suffix") String suffix, @PathVariable("version") int version,
       HttpServletRequest request)
       throws JsonProcessingException, NotFoundException {
-    var id = prefix + '/' + suffix;
+    var id = DOI_STRING + prefix + '/' + suffix;
     log.info("Received get request for specimen with id and version: {}", id);
     var specimen = service.getSpecimenByVersion(id, version, getPath(request));
     return ResponseEntity.ok(specimen);
@@ -115,7 +117,7 @@ public class DigitalSpecimenController extends BaseController {
   @GetMapping(value = "/{prefix}/{suffix}/versions", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiWrapper> getSpecimenVersions(@PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, HttpServletRequest request) throws NotFoundException {
-    var id = prefix + '/' + suffix;
+    var id = DOI_STRING + prefix + '/' + suffix;
     log.info("Received get request for specimen with id and version: {}", id);
     var versions = service.getSpecimenVersions(id, getPath(request));
     return ResponseEntity.ok(versions);

--- a/src/main/java/eu/dissco/backend/repository/MongoRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/MongoRepository.java
@@ -27,7 +27,7 @@ public class MongoRepository {
   public JsonNode getByVersion(String id, int version, String collectionName)
       throws JsonProcessingException, NotFoundException {
     var collection = database.getCollection(collectionName);
-    var versionId = "https://doi.org/" + id + '/' + version;
+    var versionId = id + '/' + version;
     var result = collection.find(eq("_id", versionId));
     if (result.first() == null) {
       throw new NotFoundException(

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -1,5 +1,6 @@
 package eu.dissco.backend.controller;
 
+import static eu.dissco.backend.TestUtils.HANDLE;
 import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.PREFIX;
@@ -18,7 +19,10 @@ import static eu.dissco.backend.utils.AnnotationUtils.givenJsonApiAnnotationRequ
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import eu.dissco.backend.component.SchemaValidatorComponent;
@@ -104,7 +108,7 @@ class AnnotationControllerTest {
     int version = 1;
     var expectedResponse = ResponseEntity.ok(
         givenAnnotationResponseSingleDataNode(ANNOTATION_PATH));
-    given(service.getAnnotationByVersion(ID, version, ANNOTATION_PATH)).willReturn(
+    given(service.getAnnotationByVersion(HANDLE + ID, version, ANNOTATION_PATH)).willReturn(
         expectedResponse.getBody());
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 
@@ -274,6 +278,7 @@ class AnnotationControllerTest {
 
     // Then
     assertThat(receivedResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    then(service).should().getAnnotationVersions(eq(HANDLE + ID), anyString());
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/controller/DigitalMediaControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/DigitalMediaControllerTest.java
@@ -1,5 +1,6 @@
 package eu.dissco.backend.controller;
 
+import static eu.dissco.backend.TestUtils.DOI;
 import static eu.dissco.backend.TestUtils.HANDLE;
 import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
@@ -17,7 +18,10 @@ import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasRequ
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -97,13 +101,14 @@ class DigitalMediaControllerTest {
 
     // Then
     assertThat(responseReceived.getStatusCode()).isEqualTo(HttpStatus.OK);
+    then(service).should().getDigitalMediaVersions(eq(DOI + ID), anyString());
   }
 
   @Test
   void testGetDigitalMediaObjectVersion() throws NotFoundException, JsonProcessingException {
     // Given
     int version = 1;
-    given(service.getDigitalMediaObjectByVersion(ID, version, DIGITAL_MEDIA_PATH)).willReturn(
+    given(service.getDigitalMediaObjectByVersion(DOI + ID, version, DIGITAL_MEDIA_PATH)).willReturn(
         givenDigitalMediaJsonResponse(DIGITAL_MEDIA_PATH, ID));
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
 

--- a/src/test/java/eu/dissco/backend/controller/DigitalSpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/DigitalSpecimenControllerTest.java
@@ -1,5 +1,6 @@
 package eu.dissco.backend.controller;
 
+import static eu.dissco.backend.TestUtils.DOI;
 import static eu.dissco.backend.TestUtils.HANDLE;
 import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import eu.dissco.backend.database.jooq.enums.JobState;
@@ -107,6 +109,7 @@ class DigitalSpecimenControllerTest {
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    then(service).should().getSpecimenByVersion(eq(DOI + ID), eq(1), anyString());
   }
 
   @Test
@@ -116,6 +119,8 @@ class DigitalSpecimenControllerTest {
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    then(service).should().getSpecimenVersions(eq(DOI + ID), anyString());
+
   }
 
   @Test
@@ -219,6 +224,7 @@ class DigitalSpecimenControllerTest {
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    then(service).should().getSpecimenByVersionFull(eq(DOI + ID), eq(1), anyString());
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/repository/MongoRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/MongoRepositoryIT.java
@@ -54,7 +54,7 @@ class MongoRepositoryIT {
     var expected = givenExpectedSpecimen(4);
 
     // When
-    var result = repository.getByVersion(ID, 4, "digital_specimen_provenance");
+    var result = repository.getByVersion(DOI + ID, 4, "digital_specimen_provenance");
 
     // Then
     assertThat(result).isEqualTo(expected.get("prov:Entity").get("prov:value"));
@@ -66,7 +66,7 @@ class MongoRepositoryIT {
 
     // When
     var exception = assertThrowsExactly(NotFoundException.class,
-        () -> repository.getByVersion(ID, 2, "digital_specimen_provenance"));
+        () -> repository.getByVersion(DOI + ID, 2, "digital_specimen_provenance"));
 
     // Then
     assertThat(exception).isInstanceOf(NotFoundException.class);
@@ -93,7 +93,7 @@ class MongoRepositoryIT {
 
     // When
     var exception = assertThrowsExactly(NotFoundException.class,
-        () -> repository.getVersions(ID, "digital_specimen_provenance"));
+        () -> repository.getVersions(DOI + ID, "digital_specimen_provenance"));
 
     // Then
     assertThat(exception).isInstanceOf(NotFoundException.class);


### PR DESCRIPTION
Mongodb prov entities have proxy in their ids. This change adds the correct proxy to the id in the controller

Mongodb indexes have also been added on these terms