### PR TITLE
tombstoning can be done by admin

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -191,8 +191,9 @@ public class AnnotationController extends BaseController {
       @PathVariable("prefix") String prefix, @PathVariable("suffix") String suffix)
       throws NoAnnotationFoundException, ForbiddenException {
     var agent = getAgent(authentication);
+    var isAdmin = isAdmin(authentication);
     log.info("Received delete for annotationRequests: {} from user: {}", (prefix + suffix), agent.getId());
-    var success = service.tombstoneAnnotation(prefix, suffix, agent);
+    var success = service.tombstoneAnnotation(prefix, suffix, agent, isAdmin);
     if (success) {
       return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     } else {

--- a/src/main/java/eu/dissco/backend/controller/BaseController.java
+++ b/src/main/java/eu/dissco/backend/controller/BaseController.java
@@ -41,7 +41,7 @@ public abstract class BaseController {
   private final ApplicationProperties applicationProperties;
 
 
-  protected Agent getAgent(Authentication authentication) throws ForbiddenException {
+  protected static Agent getAgent(Authentication authentication) throws ForbiddenException {
     var claims = ((Jwt) authentication.getPrincipal()).getClaims();
     if (claims.containsKey(ORCID)) {
       StringBuilder fullName = new StringBuilder();
@@ -77,6 +77,19 @@ public abstract class BaseController {
     } else {
       log.error("Missing ORCID in token");
       throw new ForbiddenException("Missing ORCID in token");
+    }
+  }
+
+  protected static boolean isAdmin(Authentication authentication) {
+    try {
+      var claims = ((Jwt) authentication.getPrincipal()).getClaims();
+      var roles = ((Map<String, List<String>>) claims.get("realm_access")).get("roles");
+      return (roles.contains("dissco-admin"));
+    } catch (NullPointerException e) {
+      return false;
+    } catch (ClassCastException e){
+      log.warn("Unable to read claims", e);
+      return false;
     }
   }
 

--- a/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
@@ -49,6 +49,14 @@ public class AnnotationRepository {
         .fetchOptional(this::mapToAnnotation);
   }
 
+  public Optional<Annotation> getActiveAnnotation(String id) {
+    return context.select(ANNOTATION.asterisk())
+        .from(ANNOTATION)
+        .where(ANNOTATION.ID.eq(id))
+        .and(ANNOTATION.TOMBSTONED.isNull())
+        .fetchOptional(this::mapToAnnotation);
+  }
+
   public List<Annotation> getForTarget(String id) {
     return context.select(ANNOTATION.DATA)
         .from(ANNOTATION)

--- a/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
@@ -40,21 +40,15 @@ public class AnnotationRepository {
         .limit(pageSizePlusOne).offset(offset).fetch(this::mapToAnnotation);
   }
 
-  public Optional<Annotation> getActiveAnnotationForUser(String id, String userId) {
-    return context.select(ANNOTATION.asterisk())
+  public Optional<Annotation> getActiveAnnotation(String id, String userId) {
+    var query = context.select(ANNOTATION.asterisk())
         .from(ANNOTATION)
         .where(ANNOTATION.ID.eq(id))
-        .and(ANNOTATION.CREATOR.eq(userId))
-        .and(ANNOTATION.TOMBSTONED.isNull())
-        .fetchOptional(this::mapToAnnotation);
-  }
-
-  public Optional<Annotation> getActiveAnnotation(String id) {
-    return context.select(ANNOTATION.asterisk())
-        .from(ANNOTATION)
-        .where(ANNOTATION.ID.eq(id))
-        .and(ANNOTATION.TOMBSTONED.isNull())
-        .fetchOptional(this::mapToAnnotation);
+        .and(ANNOTATION.TOMBSTONED.isNull());
+    if (userId != null) {
+      query = query.and(ANNOTATION.CREATOR.eq(userId));
+    }
+    return query.fetchOptional(this::mapToAnnotation);
   }
 
   public List<Annotation> getForTarget(String id) {

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -169,7 +169,7 @@ public class AnnotationService {
       Agent agent,
       String path, String prefix, String suffix)
       throws NoAnnotationFoundException, JsonProcessingException {
-    var result = repository.getActiveAnnotationForUser(id, agent.getId());
+    var result = repository.getActiveAnnotation(id, agent.getId());
     if (result.isPresent()) {
       if (annotationProcessingRequest.getDctermsIdentifier() == null) {
         annotationProcessingRequest.setDctermsIdentifier(id);
@@ -205,10 +205,10 @@ public class AnnotationService {
     Optional<Annotation> result;
     if (isAdmin) {
       log.info("Admin tombstoning annotation {}", id);
-      result = repository.getActiveAnnotation(id);
+      result = repository.getActiveAnnotation(id, null);
     } else {
       log.info("Creator tombstoning annotation {}", id);
-      result = repository.getActiveAnnotationForUser(id, agent.getId());
+      result = repository.getActiveAnnotation(id, agent.getId());
     }
     if (result.isPresent()) {
       annotationClient.tombstoneAnnotation(prefix, suffix,

--- a/src/test/java/eu/dissco/backend/TestUtils.java
+++ b/src/test/java/eu/dissco/backend/TestUtils.java
@@ -79,6 +79,14 @@ public class TestUtils {
     );
   }
 
+  public static Map<String, Object> givenAdminClaims() {
+    return Map.of(
+        "orcid", ORCID,
+        "given_name", "Sam",
+        "family_name", "Leeflang",
+        "realm_access", Map.of("roles", List.of("dissco-admin")));
+  }
+
   // General
   public static JsonApiLinksFull givenJsonApiLinksFull(String path, int pageNumber, int pageSize,
       boolean hasNextPage) {

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -289,8 +289,8 @@ class AnnotationControllerTest {
   }
 
   @ParameterizedTest
-  @MethodSource("nonAdminClaims")
-  void testTombstoneAnnotationSuccessNonAdmin(Map<String, Object> claims) throws Exception {
+  @MethodSource("nonValidAdminClaims")
+  void testTombstoneAnnotationSuccessNonValidAdminClaims(Map<String, Object> claims) throws Exception {
     // Given
     givenAuthentication(claims);
     given(service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), false)).willReturn(true);
@@ -302,7 +302,7 @@ class AnnotationControllerTest {
     assertThat(receivedResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
   }
 
-  private static Stream<Arguments> nonAdminClaims(){
+  private static Stream<Arguments> nonValidAdminClaims(){
     return Stream.of(
         Arguments.of(givenClaims()),
         Arguments.of(Map.of(

--- a/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
@@ -91,6 +91,21 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
+  void testGetActiveAnnotation() throws JsonProcessingException {
+    // Given
+    var annotations = List.of(givenAnnotationResponse(ID),
+        givenAnnotationResponse(USER_ID_TOKEN, "AnotherUser", PREFIX + "/TAR-GET-002"),
+        givenAnnotationResponse(USER_ID_TOKEN, "JamesBond", PREFIX + "/TAR-GET-007"));
+    postAnnotations(annotations);
+
+    // When
+    var receivedResponse = repository.getActiveAnnotation(ID);
+
+    // Then
+    assertThat(receivedResponse).isEqualTo(Optional.of(annotations.get(0)));
+  }
+
+  @Test
   void testGetForTarget() throws JsonProcessingException {
     // Given
     MAPPER.setSerializationInclusion(Include.ALWAYS);

--- a/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
@@ -84,7 +84,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     postAnnotations(annotations);
 
     // When
-    var receivedResponse = repository.getActiveAnnotationForUser(ID, ORCID);
+    var receivedResponse = repository.getActiveAnnotation(ID, ORCID);
 
     // Then
     assertThat(receivedResponse).isEqualTo(Optional.of(annotations.get(0)));
@@ -99,7 +99,7 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
     postAnnotations(annotations);
 
     // When
-    var receivedResponse = repository.getActiveAnnotation(ID);
+    var receivedResponse = repository.getActiveAnnotation(ID, null);
 
     // Then
     assertThat(receivedResponse).isEqualTo(Optional.of(annotations.get(0)));

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -478,7 +478,19 @@ class AnnotationServiceTest {
     given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
 
     // When
-    var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent());
+    var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), false);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testTombstoneAnnotationAmin() throws Exception {
+    // Given
+    given(repository.getActiveAnnotation(ID)).willReturn(Optional.of(givenAnnotationResponse()));
+
+    // When
+    var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), true);
 
     // Then
     assertThat(result).isTrue();
@@ -491,7 +503,7 @@ class AnnotationServiceTest {
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,
-        () -> service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent()));
+        () -> service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), false));
   }
 
 }

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -407,7 +407,7 @@ class AnnotationServiceTest {
   void testUpdateAnnotation() throws Exception {
     // Given
     var expected = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH, ORCID);
-    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
     var kafkaResponse = MAPPER.valueToTree(givenAnnotationResponse());
     given(annotationClient.updateAnnotation(any(), any(), any()))
         .willReturn(kafkaResponse);
@@ -424,7 +424,7 @@ class AnnotationServiceTest {
   @Test
   void testUpdateAnnotationDoesNotExist() {
     // Given
-    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
+    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,
@@ -475,7 +475,7 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotation() throws Exception {
     // Given
-    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
 
     // When
     var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), false);
@@ -487,7 +487,7 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotationAmin() throws Exception {
     // Given
-    given(repository.getActiveAnnotation(ID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotation(ID, null)).willReturn(Optional.of(givenAnnotationResponse()));
 
     // When
     var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), true);
@@ -499,7 +499,7 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotationDoesNotExist() {
     // Given
-    given(repository.getActiveAnnotationForUser(ID, ORCID)).willReturn(Optional.empty());
+    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(Optional.empty());
 
     // Then
     assertThrowsExactly(NoAnnotationFoundException.class,


### PR DESCRIPTION
Tombstoning can be done by users with role dissco-admin

The `isAdmin()` check can be applied to other operations as use cases arise

Sonar is whining about 92.6% test coverage, it's just a log message 