### PR TITLE
remove latest annotation endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version>
+    <version>3.4.1</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>
@@ -19,15 +19,17 @@
     <elasticsearch.version>8.15.0</elasticsearch.version>
     <feign-okhttp.version>13.5</feign-okhttp.version>
     <jakarta.json.version>2.1.3</jakarta.json.version>
+    <jooq.version>3.19.14</jooq.version>
     <json-path.version>2.9.0</json-path.version>
     <json-schema-validator.version>1.5.1</json-schema-validator.version>
     <mongodb-driver.version>5.1.3</mongodb-driver.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
-    <spring-cloud.version>2023.0.3</spring-cloud.version>
+    <spring-cloud.version>2024.0.0</spring-cloud.version>
     <springdoc.version>2.6.0</springdoc.version>
     <testcontainers.version>1.20.1</testcontainers.version>
     <sonar.organization>dissco</sonar.organization>
+    <okhttp.version>4.12.0</okhttp.version>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>../app-it/target/site/jacoco-aggregate/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
@@ -193,11 +195,13 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -85,25 +85,6 @@ public class AnnotationController extends BaseController {
     return ResponseEntity.ok(annotation);
   }
 
-  @Operation(summary = "Get latest annotations, paginated")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Annotations retrieved", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = AnnotationResponseList.class))
-      })
-  })
-  @GetMapping(value = "/latest", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonApiListResponseWrapper> getLatestAnnotations(
-      @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
-      @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
-      HttpServletRequest request)
-      throws IOException {
-    log.info(
-        "Received get request for latest paginated annotationRequests. Page number: {}, page size {}",
-        pageNumber, pageSize);
-    var annotations = service.getLatestAnnotations(pageNumber, pageSize, getPath(request));
-    return ResponseEntity.ok(annotations);
-  }
-
   @Operation(summary = "Get annotation by ID and desired version")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Annotation successfully retrieved", content = {

--- a/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
@@ -89,19 +89,6 @@ public class ElasticSearchRepository {
     return getDigitalSpecimenSearchResults(searchRequest);
   }
 
-  public List<Annotation> getLatestAnnotations(int pageNumber, int pageSize)
-      throws IOException {
-    var offset = getOffset(pageNumber, pageSize);
-    var pageSizePlusOne = pageSize + ONE_TO_CHECK_NEXT;
-    var searchRequest = new SearchRequest.Builder()
-        .index(properties.getAnnotationIndex())
-        .sort(s -> s.field(f -> f.field(FIELD_CREATED).order(SortOrder.Desc)))
-        .from(offset)
-        .size(pageSizePlusOne).build();
-    return client.search(searchRequest, ObjectNode.class).hits().hits().stream().map(Hit::source)
-        .map(this::mapToAnnotationResponse).toList();
-  }
-
   private Annotation mapToAnnotationResponse(ObjectNode annotationNode) {
     try {
       return mapper.treeToValue(annotationNode, Annotation.class);

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -58,12 +58,6 @@ public class AnnotationService {
     return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
   }
 
-  public JsonApiListResponseWrapper getLatestAnnotations(int pageNumber, int pageSize,
-      String path) throws IOException {
-    var annotationsPlusOne = elasticRepository.getLatestAnnotations(pageNumber, pageSize);
-    return wrapListResponse(annotationsPlusOne, pageNumber, pageSize, path);
-  }
-
   public JsonApiWrapper getAnnotationByVersion(String id, int version, String path)
       throws NotFoundException, JsonProcessingException {
     var eventNode = mongoRepository.getByVersion(id, version, "annotation_provenance");

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -41,7 +41,6 @@ import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.properties.ApplicationProperties;
 import eu.dissco.backend.schema.AnnotationProcessingRequest;
 import eu.dissco.backend.service.AnnotationService;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -94,27 +93,6 @@ class AnnotationControllerTest {
     // Then
     assertThat(receivedResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(receivedResponse.getBody()).isEqualTo(expectedResponse);
-  }
-
-  @Test
-  void testGetLatestAnnotations() throws IOException {
-    // Given
-    int pageNumber = 1;
-    int pageSize = 11;
-    String annotationId = "123";
-    var expectedJson = givenAnnotationJsonResponse(ANNOTATION_PATH, pageNumber, pageSize,
-        USER_ID_TOKEN, annotationId, true);
-    var expectedResponse = ResponseEntity.ok(expectedJson);
-    given(service.getLatestAnnotations(pageNumber, pageSize, ANNOTATION_PATH)).willReturn(
-        expectedJson);
-    given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");
-
-    // When
-    var receivedResponse = controller.getLatestAnnotations(pageNumber, pageSize,
-        mockRequest);
-
-    // Then
-    assertThat(receivedResponse).isEqualTo(expectedResponse);
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -376,58 +376,6 @@ class ElasticSearchRepositoryIT {
   }
 
   @Test
-  void testGetLatestAnnotations() throws IOException {
-    // Given
-    int pageNumber = 1;
-    int pageSize = 10;
-    List<Annotation> givenAnnotations = new ArrayList<>();
-    List<Annotation> expected = new ArrayList<>();
-    for (int i = 0; i < pageSize + 1; i++) {
-      String id = HANDLE + PREFIX + "/" + i;
-      var annotation = givenAnnotationResponse(id);
-      expected.add(givenAnnotationResponse(id));
-      givenAnnotations.add(annotation);
-    }
-    for (int i = 11; i < pageSize * 2; i++) {
-      var annotation = givenAnnotationResponse(HANDLE + PREFIX + "/" + i);
-      givenAnnotations.add(annotation);
-    }
-    postAnnotations(parseAnnotationToElasticFormat(givenAnnotations));
-
-    // When
-    var responseReceived = repository.getLatestAnnotations(pageNumber, pageSize);
-
-    // Then
-    assertThat(responseReceived).hasSize(11).hasSameElementsAs(expected);
-  }
-
-  @Test
-  void testGetLatestAnnotationsNullAggregate() throws IOException {
-    // Given
-    int pageNumber = 1;
-    int pageSize = 10;
-    List<Annotation> givenAnnotations = new ArrayList<>();
-    List<Annotation> expected = new ArrayList<>();
-    for (int i = 0; i < pageSize + 1; i++) {
-      String id = HANDLE + PREFIX + "/" + i;
-      var annotation = givenAnnotationResponse(id);
-      expected.add(givenAnnotationResponse(id).withOdsHasAggregateRating(null));
-      givenAnnotations.add(annotation.withOdsHasAggregateRating(null));
-    }
-    for (int i = 11; i < pageSize * 2; i++) {
-      var annotation = givenAnnotationResponse(HANDLE + PREFIX + "/" + i);
-      givenAnnotations.add(annotation);
-    }
-    postAnnotations(parseAnnotationToElasticFormat(givenAnnotations));
-
-    // When
-    var responseReceived = repository.getLatestAnnotations(pageNumber, pageSize);
-
-    // Then
-    assertThat(responseReceived).hasSize(11).hasSameElementsAs(expected);
-  }
-
-  @Test
   void testGetAnnotationsForCreator() throws IOException {
     // Given
     int pageNumber = 1;

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -40,12 +40,10 @@ import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.repository.AnnotationRepository;
 import eu.dissco.backend.repository.ElasticSearchRepository;
 import eu.dissco.backend.repository.MongoRepository;
-import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
@@ -219,23 +217,6 @@ class AnnotationServiceTest {
   }
 
   @Test
-  void testGetLatestAnnotations() throws IOException {
-    int pageSize = 15;
-    int pageNumber = 1;
-    String path = SANDBOX_URI + "api/v1/annotationRequests/latest/json";
-    var expected = givenAnnotationJsonResponse(path, pageNumber, pageSize,
-        ORCID, ID, true);
-    var elasticResponse = Collections.nCopies(pageSize + 1, givenAnnotationResponse(ID));
-    given(elasticRepository.getLatestAnnotations(pageNumber, pageSize)).willReturn(elasticResponse);
-
-    // When
-    var received = service.getLatestAnnotations(pageNumber, pageSize, path);
-
-    // Then
-    assertThat(received).isEqualTo(expected);
-  }
-
-  @Test
   void testPersistAnnotationBatch() throws Exception {
     // Given
     var annotationRequest = givenAnnotationRequest();
@@ -250,23 +231,6 @@ class AnnotationServiceTest {
 
     // Then
     assertThat(responseReceived).isEqualTo(expected);
-  }
-
-  @Test
-  void testGetLatestAnnotationsLastPage() throws IOException {
-    int pageSize = 15;
-    int pageNumber = 1;
-    String path = SANDBOX_URI + "api/v1/annotationRequests/latest/json";
-    var expected = givenAnnotationJsonResponse(path, pageNumber, pageSize,
-        ORCID, ID, false);
-    var elasticResponse = Collections.nCopies(pageSize, givenAnnotationResponse(ID));
-    given(elasticRepository.getLatestAnnotations(pageNumber, pageSize)).willReturn(elasticResponse);
-
-    // When
-    var received = service.getLatestAnnotations(pageNumber, pageSize, path);
-
-    // Then
-    assertThat(received).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
Also upgrades to spring 3.4.1
- manage jooq version: 3.19.14
- manage  okhttp version 4.12.0
- upgrade spring cloud to 2024.0.0

[Jira](https://naturalis.atlassian.net/browse/DD-1522?atlOrigin=eyJpIjoiMjNhMjk3YTFkNjc3NDFmYTg4ZmRkYmZiNDBkNzQxNWYiLCJwIjoiaiJ9)