### PR TITLE
elvis services

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,13 +18,13 @@ jobs:
         with:
           java-version: 17
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
     <spring-cloud.version>2024.0.0</spring-cloud.version>
-    <springdoc.version>2.6.0</springdoc.version>
+    <springdoc.version>2.8.3</springdoc.version>
     <testcontainers.version>1.20.1</testcontainers.version>
     <sonar.organization>dissco</sonar.organization>
     <okhttp.version>4.12.0</okhttp.version>

--- a/src/main/java/eu/dissco/backend/controller/ElvisController.java
+++ b/src/main/java/eu/dissco/backend/controller/ElvisController.java
@@ -9,9 +9,11 @@ import static eu.dissco.backend.controller.BaseController.SUFFIX_OAS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.domain.elvis.InventoryNumberSuggestionResponse;
 import eu.dissco.backend.service.ElvisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -41,7 +43,7 @@ public class ElvisController {
   @Operation(summary = "Searches DiSSCo specimens by inventory number (also known as physical specimen ID)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
+          @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ElvisSpecimen.class)))
       })
   })
   @GetMapping(value = "/inventory", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -71,11 +73,12 @@ public class ElvisController {
   @Operation(summary = "Searches DiSSCo specimens by inventory number (also known as physical specimen ID)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
+          @Content(mediaType = "application/json",
+              array = @ArraySchema(schema = @Schema(implementation = InventoryNumberSuggestionResponse.class)))
       })
   })
   @GetMapping(value = "/suggest", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonNode> suggestInventoryNumber(
+  public ResponseEntity<InventoryNumberSuggestionResponse> suggestInventoryNumber(
       @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
       @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize

--- a/src/main/java/eu/dissco/backend/controller/ElvisController.java
+++ b/src/main/java/eu/dissco/backend/controller/ElvisController.java
@@ -1,0 +1,87 @@
+package eu.dissco.backend.controller;
+
+import static eu.dissco.backend.controller.BaseController.DEFAULT_PAGE_NUM;
+import static eu.dissco.backend.controller.BaseController.DEFAULT_PAGE_SIZE;
+import static eu.dissco.backend.controller.BaseController.PAGE_NUM_OAS;
+import static eu.dissco.backend.controller.BaseController.PAGE_SIZE_OAS;
+import static eu.dissco.backend.controller.BaseController.PREFIX_OAS;
+import static eu.dissco.backend.controller.BaseController.SUFFIX_OAS;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.service.ElvisService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RestController
+@RequestMapping("/elvis/v1")
+@RequiredArgsConstructor
+public class ElvisController {
+
+  private final ElvisService elvisService;
+
+
+  @Operation(summary = "Searches DiSSCo specimens by inventory number (also known as physical specimen ID)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
+      })
+  })
+  @GetMapping(value = "/specimen/inventory", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonNode> getSpecimenByInventoryNumber(
+      @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
+      @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
+      @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize
+  ) throws IOException {
+    return ResponseEntity.ok()
+        .body(elvisService.searchBySpecimenId(inventoryNumber, pageNumber, pageSize));
+  }
+
+  @Operation(summary = "Get specimen from DiSSCo DOI")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
+      })
+  })
+  @GetMapping(value = "/specimen/doi/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ElvisSpecimen> getSpecimenByDoi(
+      @Parameter(description = PREFIX_OAS) @PathVariable("prefix") String prefix,
+      @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix) {
+    var id = prefix + "/" + suffix;
+    return ResponseEntity.ok().body(elvisService.searchByDoi(id));
+  }
+
+  @Operation(summary = "Searches DiSSCo specimens by inventory number (also known as physical specimen ID)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
+      })
+  })
+  @GetMapping(value = "/specimen/suggest", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<JsonNode> suggestInventoryNumber(
+      @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
+      @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
+      @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize
+  ) throws IOException {
+    return ResponseEntity.ok()
+        .body(elvisService.suggestInventoryNumber(inventoryNumber, pageNumber, pageSize));
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/controller/ElvisController.java
+++ b/src/main/java/eu/dissco/backend/controller/ElvisController.java
@@ -8,8 +8,8 @@ import static eu.dissco.backend.controller.BaseController.PREFIX_OAS;
 import static eu.dissco.backend.controller.BaseController.SUFFIX_OAS;
 
 import eu.dissco.backend.domain.elvis.ElvisSpecimen;
-import eu.dissco.backend.domain.elvis.ElvisSpecimenBatchResponse;
 import eu.dissco.backend.domain.elvis.InventoryNumberSuggestionResponse;
+import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.service.ElvisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,23 +39,6 @@ public class ElvisController {
 
   private final ElvisService elvisService;
 
-
-  @Operation(summary = "Searches DiSSCo specimens by inventory number (also known as physical specimen ID)")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimenBatchResponse.class))
-      })
-  })
-  @GetMapping(value = "/inventory", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<ElvisSpecimenBatchResponse> getSpecimenByInventoryNumber(
-      @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
-      @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
-      @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize
-  ) throws IOException {
-    return ResponseEntity.ok()
-        .body(elvisService.searchBySpecimenId(inventoryNumber, pageNumber, pageSize));
-  }
-
   @Operation(summary = "Get specimen from DiSSCo DOI")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
@@ -65,7 +48,7 @@ public class ElvisController {
   @GetMapping(value = "/doi/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<ElvisSpecimen> getSpecimenByDoi(
       @Parameter(description = PREFIX_OAS) @PathVariable("prefix") String prefix,
-      @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix) {
+      @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix) throws NotFoundException  {
     var id = prefix + "/" + suffix;
     return ResponseEntity.ok().body(elvisService.searchByDoi(id));
   }
@@ -82,7 +65,7 @@ public class ElvisController {
       @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
       @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize
-  ) throws IOException {
+  ) throws IOException, NotFoundException {
     return ResponseEntity.ok()
         .body(elvisService.suggestInventoryNumber(inventoryNumber, pageNumber, pageSize));
   }

--- a/src/main/java/eu/dissco/backend/controller/ElvisController.java
+++ b/src/main/java/eu/dissco/backend/controller/ElvisController.java
@@ -7,8 +7,8 @@ import static eu.dissco.backend.controller.BaseController.PAGE_SIZE_OAS;
 import static eu.dissco.backend.controller.BaseController.PREFIX_OAS;
 import static eu.dissco.backend.controller.BaseController.SUFFIX_OAS;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.domain.elvis.ElvisSpecimenBatchResponse;
 import eu.dissco.backend.domain.elvis.InventoryNumberSuggestionResponse;
 import eu.dissco.backend.service.ElvisService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,11 +43,11 @@ public class ElvisController {
   @Operation(summary = "Searches DiSSCo specimens by inventory number (also known as physical specimen ID)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Specimen successfully retrieved", content = {
-          @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = ElvisSpecimen.class)))
+          @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimenBatchResponse.class))
       })
   })
   @GetMapping(value = "/inventory", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonNode> getSpecimenByInventoryNumber(
+  public ResponseEntity<ElvisSpecimenBatchResponse> getSpecimenByInventoryNumber(
       @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
       @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize

--- a/src/main/java/eu/dissco/backend/controller/ElvisController.java
+++ b/src/main/java/eu/dissco/backend/controller/ElvisController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 @RestController
-@RequestMapping("/elvis/v1")
+@RequestMapping("/elvis")
 @RequiredArgsConstructor
 public class ElvisController {
 
@@ -44,7 +44,7 @@ public class ElvisController {
           @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
       })
   })
-  @GetMapping(value = "/specimen/inventory", produces = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/inventory", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonNode> getSpecimenByInventoryNumber(
       @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
@@ -60,7 +60,7 @@ public class ElvisController {
           @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
       })
   })
-  @GetMapping(value = "/specimen/doi/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/doi/{prefix}/{suffix}", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<ElvisSpecimen> getSpecimenByDoi(
       @Parameter(description = PREFIX_OAS) @PathVariable("prefix") String prefix,
       @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix) {
@@ -74,7 +74,7 @@ public class ElvisController {
           @Content(mediaType = "application/json", schema = @Schema(implementation = ElvisSpecimen.class))
       })
   })
-  @GetMapping(value = "/specimen/suggest", produces = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/suggest", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonNode> suggestInventoryNumber(
       @Parameter(description = "Inventory number (physical specimen id}") @RequestParam("inventoryNumber") String inventoryNumber,
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,

--- a/src/main/java/eu/dissco/backend/controller/ElvisRestResponseEntityExceptionHandler.java
+++ b/src/main/java/eu/dissco/backend/controller/ElvisRestResponseEntityExceptionHandler.java
@@ -1,0 +1,27 @@
+package eu.dissco.backend.controller;
+
+import eu.dissco.backend.exceptions.NotFoundException;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice(assignableTypes = ElvisController.class)
+public class ElvisRestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<Void> handleNotFoundElvis(NotFoundException e){
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(IOException.class)
+  public ResponseEntity<Void> handleIOExceptionElvis(IOException e){
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+  }
+
+}

--- a/src/main/java/eu/dissco/backend/controller/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/eu/dissco/backend/controller/RestResponseEntityExceptionHandler.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-@ControllerAdvice
+@ControllerAdvice(assignableTypes = BaseController.class)
 public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
@@ -5,13 +5,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = """
     Schema for ELViS specimen.
+    
     If no value for a given term is present, an empty string is returned.
-    Where possible, taxonomic terms come from the accepted identification. If there is no accepted identification, the first identification is used.
-    Some identifications may have multiple taxonomic identifications. This occurs when a specimen contains multiple subjects (e.g. a rock with multiple fossils). 
-    In this case, the first two taxonomies are presented, and the string "and x more" is appended. 
+    
+    Where possible, taxonomic terms come from the "accepted Identification". If there is no accepted Identification, the first Identification is used.
+    Some Identifications contain have multiple taxonomies. This occurs when a specimen contains multiple subjects (e.g. a rock with multiple fossils).
+    In this case, the response includes the first two taxonomies then "and x more" is appended.
     """)
 public record ElvisSpecimen(
-    @Schema(description = "ods:physicalSpecimenId") String inventoryNumber,
+    @Schema(description = "dcterms:identifier, the DOI of the specimen") String inventoryNumber,
     @Schema(description = "Concatenation of ods:specimenName physicalSpecimenID, ods:OrganisationName") String title,
     @Schema(description = "dwc:collectionCode") String collectionCode,
     @Schema(description = "dwc:physicalSpecimenID") String catalogNumber,
@@ -24,5 +26,4 @@ public record ElvisSpecimen(
     @Schema(description = "dwc:family") String family,
     @Schema(description = "dwc:genus") String genus,
     @Schema(description = "dwc:vernacularName") String vernacularName) {
-
 }

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
@@ -1,0 +1,24 @@
+package eu.dissco.backend.domain.elvis;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Schema for ELViS specimen. Note: where possible, taxonomic terms come from the accepted identification. If there is no accepted identification, the first identification is used.")
+public record ElvisSpecimen(
+    @Schema(description = "ods:physicalSpecimenId") String inventoryNumber,
+    @Schema(description = "ods:specimenName") String title,
+    @Schema(description = "dcterms:identifier") String identifier,
+    @Schema(description = "dwc:collectionCode") String collectionCode,
+    @Schema(description = "dwc:collectionID") String catalogNumber,
+    @Schema(description = "ods:organisationID") String institutionId,
+    @Schema(description = "ods:organisationCode") String institutionCode,
+    @Schema(description = "dwc:basisOfRecord") String basisOfRecord,
+    @JsonProperty(value = "URI") @Schema(description = "Resolves to human-readable specimen landing page on DiSSCo") String uri,
+    @Schema(description = "dwc:scientificName") String scientificName,
+    @Schema(description = "dwc:scientificNameAuthorship") String scientificNameAuthorship,
+    @Schema(description = "dwc:specificEptitet") String specificEpithet,
+    @Schema(description = "dwc:family") String family,
+    @Schema(description = "dwc:genus") String genus,
+    @Schema(description = "dwc:vernacularName") String vernacularName) {
+
+}

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
@@ -3,17 +3,21 @@ package eu.dissco.backend.domain.elvis;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "Schema for ELViS specimen. Note: where possible, taxonomic terms come from the accepted identification. If there is no accepted identification, the first identification is used.")
+@Schema(description = """
+    Schema for ELViS specimen.
+    If no value for a given term is present, an empty string is returned.
+    Where possible, taxonomic terms come from the accepted identification. If there is no accepted identification, the first identification is used.
+    Some identifications may have multiple taxonomic identifications. This occurs when a specimen contains multiple subjects (e.g. a rock with multiple fossils). 
+    In this case, the first two taxonomies are presented, and the string "and x more" is appended. 
+    """)
 public record ElvisSpecimen(
     @Schema(description = "ods:physicalSpecimenId") String inventoryNumber,
     @Schema(description = "dwc:scientificName ods:organisationCode-dwc:collectionCode-dwc:collectionId") String title,
-    @Schema(description = "dcterms:identifier") String identifier,
     @Schema(description = "dwc:collectionCode") String collectionCode,
-    @Schema(description = "dwc:collectionID") String catalogNumber,
-    @Schema(description = "ods:organisationID") String institutionId,
+    @Schema(description = "dwc:physicalSpecimenID") String catalogNumber,
     @Schema(description = "ods:organisationCode") String institutionCode,
     @Schema(description = "dwc:basisOfRecord") String basisOfRecord,
-    @JsonProperty(value = "URI") @Schema(description = "Resolves to human-readable specimen landing page on DiSSCo") String uri,
+    @JsonProperty(value = "URI") @Schema(description = "DOI that resolves to human-readable specimen landing page on DiSSCo") String uri,
     @Schema(description = "dwc:scientificName") String scientificName,
     @Schema(description = "dwc:scientificNameAuthorship") String scientificNameAuthorship,
     @Schema(description = "dwc:specificEptitet") String specificEpithet,

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Schema for ELViS specimen. Note: where possible, taxonomic terms come from the accepted identification. If there is no accepted identification, the first identification is used.")
 public record ElvisSpecimen(
     @Schema(description = "ods:physicalSpecimenId") String inventoryNumber,
-    @Schema(description = "ods:specimenName") String title,
+    @Schema(description = "dwc:scientificName ods:organisationCode-dwc:collectionCode-dwc:collectionId") String title,
     @Schema(description = "dcterms:identifier") String identifier,
     @Schema(description = "dwc:collectionCode") String collectionCode,
     @Schema(description = "dwc:collectionID") String catalogNumber,

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
     """)
 public record ElvisSpecimen(
     @Schema(description = "ods:physicalSpecimenId") String inventoryNumber,
-    @Schema(description = "dwc:scientificName ods:organisationCode-dwc:collectionCode-dwc:collectionId") String title,
+    @Schema(description = "Concatenation of ods:specimenName physicalSpecimenID, ods:OrganisationName") String title,
     @Schema(description = "dwc:collectionCode") String collectionCode,
     @Schema(description = "dwc:physicalSpecimenID") String catalogNumber,
     @Schema(description = "ods:organisationCode") String institutionCode,

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimen.java
@@ -20,7 +20,7 @@ public record ElvisSpecimen(
     @JsonProperty(value = "URI") @Schema(description = "DOI that resolves to human-readable specimen landing page on DiSSCo") String uri,
     @Schema(description = "dwc:scientificName") String scientificName,
     @Schema(description = "dwc:scientificNameAuthorship") String scientificNameAuthorship,
-    @Schema(description = "dwc:specificEptitet") String specificEpithet,
+    @Schema(description = "dwc:specificEpithet") String specificEpithet,
     @Schema(description = "dwc:family") String family,
     @Schema(description = "dwc:genus") String genus,
     @Schema(description = "dwc:vernacularName") String vernacularName) {

--- a/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimenBatchResponse.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/ElvisSpecimenBatchResponse.java
@@ -1,0 +1,13 @@
+package eu.dissco.backend.domain.elvis;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema
+public record ElvisSpecimenBatchResponse(
+    @Schema(example = "3")
+    Long total,
+    List<ElvisSpecimen> specimens
+) {
+
+}

--- a/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
@@ -1,0 +1,8 @@
+package eu.dissco.backend.domain.elvis;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema()
+public record InventoryNumberSuggestion(String catalogNumber, String inventoryNumber, String identifier) {
+
+}

--- a/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
@@ -2,7 +2,7 @@ package eu.dissco.backend.domain.elvis;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema
+@Schema(description = "Suggestions for key identifiers")
 public record InventoryNumberSuggestion(
     @Schema(description = "ods:physicalSpecimenId")
     String catalogNumber,

--- a/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
@@ -2,7 +2,13 @@ package eu.dissco.backend.domain.elvis;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema()
-public record InventoryNumberSuggestion(String catalogNumber, String inventoryNumber, String identifier) {
+@Schema
+public record InventoryNumberSuggestion(
+    @Schema(description = "dwc:collectionID")
+    String catalogNumber,
+    @Schema(description = "ods:physicalSpecimenId")
+    String inventoryNumber,
+    @Schema(description = "dcterms:identifier")
+    String identifier) {
 
 }

--- a/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestion.java
@@ -4,11 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema
 public record InventoryNumberSuggestion(
-    @Schema(description = "dwc:collectionID")
-    String catalogNumber,
     @Schema(description = "ods:physicalSpecimenId")
-    String inventoryNumber,
+    String catalogNumber,
     @Schema(description = "dcterms:identifier")
-    String identifier) {
+    String inventoryNumber) {
 
 }

--- a/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestionResponse.java
+++ b/src/main/java/eu/dissco/backend/domain/elvis/InventoryNumberSuggestionResponse.java
@@ -1,0 +1,13 @@
+package eu.dissco.backend.domain.elvis;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema
+public record InventoryNumberSuggestionResponse(
+    @Schema(example = "3")
+    Long total,
+    List<InventoryNumberSuggestion> inventoryNumbers
+) {
+
+}

--- a/src/main/java/eu/dissco/backend/exceptions/UserExistsException.java
+++ b/src/main/java/eu/dissco/backend/exceptions/UserExistsException.java
@@ -1,5 +1,0 @@
-package eu.dissco.backend.exceptions;
-
-public class UserExistsException extends ConflictException {
-
-}

--- a/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/ElasticSearchRepository.java
@@ -148,7 +148,6 @@ public class ElasticSearchRepository {
   public Pair<Long, List<DigitalSpecimen>> elvisSearch(Map<String, List<String>> params,
       int pageNumber, int pageSize) throws IOException {
     var offset = getOffset(pageNumber, pageSize);
-    var pageSizePlusOne = pageSize + ONE_TO_CHECK_NEXT;
     var queries = new ArrayList<Query>();
     for (var entry : params.entrySet()) {
       entry.getValue().forEach(value ->
@@ -162,7 +161,7 @@ public class ElasticSearchRepository {
             q -> q.bool(b -> b.should(queries).minimumShouldMatch("1")))
         .trackTotalHits(t -> t.enabled(Boolean.TRUE))
         .from(offset)
-        .size(pageSizePlusOne).build();
+        .size(pageSize).build();
     return getDigitalSpecimenSearchResults(searchRequest);
   }
 

--- a/src/main/java/eu/dissco/backend/service/ElvisService.java
+++ b/src/main/java/eu/dissco/backend/service/ElvisService.java
@@ -1,0 +1,118 @@
+package eu.dissco.backend.service;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.domain.elvis.InventoryNumberSuggestion;
+import eu.dissco.backend.properties.ApplicationProperties;
+import eu.dissco.backend.repository.DigitalSpecimenRepository;
+import eu.dissco.backend.repository.ElasticSearchRepository;
+import eu.dissco.backend.schema.DigitalSpecimen;
+import eu.dissco.backend.schema.TaxonIdentification;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ElvisService {
+
+  private final DigitalSpecimenRepository repository;
+  private final ElasticSearchRepository elasticSearchRepository;
+  private final ApplicationProperties applicationProperties;
+  private final ObjectMapper mapper;
+
+  public ElvisSpecimen searchByDoi(String id) {
+    var specimen = repository.getLatestSpecimenById(id);
+    return buildElvisSpecimen(specimen, applicationProperties.getBaseUrl());
+  }
+
+  public JsonNode searchBySpecimenId(String inventoryNumber, int pageNumber, int pageSize)
+      throws IOException {
+    var results = searchElastic(inventoryNumber, pageNumber, pageSize);
+    var elvisSpecimens = results.getRight().stream()
+        .map(specimen -> buildElvisSpecimen(specimen, applicationProperties.getBaseUrl())).toList();
+    return mapper.createObjectNode()
+        .put("total", results.getLeft())
+        .set("specimens", mapper.valueToTree(elvisSpecimens));
+  }
+
+  public JsonNode suggestInventoryNumber(String inventoryNumber, int pageNumber, int pageSize)
+      throws IOException {
+    var results = searchElastic(inventoryNumber, pageNumber, pageSize);
+    var specimenList = results.getRight();
+    var inventoryNumbers = specimenList.stream().map(
+        specimen -> new InventoryNumberSuggestion(specimen.getDwcCollectionID(),
+            specimen.getOdsPhysicalSpecimenID(), specimen.getDctermsIdentifier())).toList();
+    return mapper.createObjectNode()
+        .put("total", results.getLeft())
+        .set("inventoryNumbers", mapper.valueToTree(inventoryNumbers));
+  }
+
+  private Pair<Long, List<DigitalSpecimen>> searchElastic(String inventoryNumber, int pageNumber,
+      int pageSize)
+      throws IOException {
+    var map = Map.of("ods:physicalSpecimenID.keyword", List.of(inventoryNumber));
+    return elasticSearchRepository.search(map, pageNumber, pageSize);
+  }
+
+
+  private static ElvisSpecimen buildElvisSpecimen(DigitalSpecimen digitalSpecimen, String url) {
+    var inventoryNumber = digitalSpecimen.getOdsPhysicalSpecimenID();
+    var title = digitalSpecimen.getOdsSpecimenName();
+    var identifier = digitalSpecimen.getDctermsIdentifier();
+    var collectionCode = digitalSpecimen.getDwcCollectionCode();
+    var catalogNumber = digitalSpecimen.getDwcCollectionID();
+    var institutionId = digitalSpecimen.getOdsOrganisationID();
+    var institutionCode = digitalSpecimen.getOdsOrganisationCode();
+    var basisOfRecord = digitalSpecimen.getDwcBasisOfRecord();
+    var uri = url + "/ds/" + digitalSpecimen.getId();
+    var taxonId = getBestTaxonIdentification(digitalSpecimen);
+    String scientificName = null;
+    String scientificNameAuthorship = null;
+    String specificEpithet = null;
+    String family = null;
+    String genus = null;
+    String vernacularName = null;
+    if (taxonId.isPresent()) {
+      scientificName = taxonId.get().getDwcScientificName();
+      scientificNameAuthorship = taxonId.get().getDwcScientificNameAuthorship();
+      specificEpithet = taxonId.get().getDwcSpecificEpithet();
+      family = taxonId.get().getDwcFamily();
+      genus = taxonId.get().getDwcVernacularName();
+      vernacularName = taxonId.get().getDwcVernacularName();
+    }
+    return new ElvisSpecimen(inventoryNumber, title, identifier, collectionCode, catalogNumber, institutionId,
+        institutionCode, basisOfRecord, uri, scientificName, scientificNameAuthorship,
+        specificEpithet, family, genus, vernacularName);
+  }
+
+  private static Optional<TaxonIdentification> getBestTaxonIdentification(
+      DigitalSpecimen digitalSpecimen) {
+    if (digitalSpecimen.getOdsHasIdentifications().isEmpty()
+        || digitalSpecimen.getOdsHasIdentifications().get(0).getOdsHasTaxonIdentifications()
+        .isEmpty()) {
+      return Optional.empty();
+    }
+    // First, try to find accepted id
+    for (var identification : digitalSpecimen.getOdsHasIdentifications()) {
+      if (Boolean.TRUE.equals(identification.getOdsIsVerifiedIdentification())) {
+        if (identification.getOdsHasTaxonIdentifications().isEmpty()) {
+          return Optional.empty();
+        } else {
+          return Optional.of(identification.getOdsHasTaxonIdentifications().get(0));
+        }
+      }
+    }
+    // If no accepted id, take the first
+    return Optional.of(
+        digitalSpecimen.getOdsHasIdentifications().get(0).getOdsHasTaxonIdentifications().get(0));
+  }
+
+
+}

--- a/src/main/java/eu/dissco/backend/service/ElvisService.java
+++ b/src/main/java/eu/dissco/backend/service/ElvisService.java
@@ -28,16 +28,16 @@ public class ElvisService {
 
   public ElvisSpecimen searchByDoi(String id) throws NotFoundException {
     var specimen = repository.getLatestSpecimenById(id);
-    if (specimen ==  null) {
+    if (specimen == null) {
       throw new NotFoundException();
     }
     return buildElvisSpecimen(specimen);
   }
 
-  public InventoryNumberSuggestionResponse suggestInventoryNumber(String inventoryNumber,
+  public InventoryNumberSuggestionResponse suggestInventoryNumber(String searchValue,
       int pageNumber, int pageSize) throws IOException, NotFoundException {
-    var results = searchElastic(inventoryNumber, pageNumber, pageSize);
-    if (results.getLeft().equals(0L)){
+    var results = searchElastic(searchValue, pageNumber, pageSize);
+    if (results.getLeft().equals(0L)) {
       throw new NotFoundException();
     }
     var specimenList = results.getRight();

--- a/src/main/java/eu/dissco/backend/service/ElvisService.java
+++ b/src/main/java/eu/dissco/backend/service/ElvisService.java
@@ -100,17 +100,11 @@ public class ElvisService {
     if (digitalSpecimen.getOdsSpecimenName() != null) {
       title.append(digitalSpecimen.getOdsSpecimenName()).append(" ");
     }
-    if (digitalSpecimen.getOdsOrganisationCode() != null) {
-      title.append(digitalSpecimen.getOdsOrganisationCode()).append("-");
-    }
-    if (digitalSpecimen.getDwcCollectionCode() != null) {
-      title.append(digitalSpecimen.getDwcCollectionCode()).append("-");
-    }
     title
         .append(digitalSpecimen.getOdsPhysicalSpecimenID())
         .append(", ")
         .append(digitalSpecimen.getOdsOrganisationName());
-    return title.toString().replace("--", "");
+    return title.toString();
   }
 
   private static List<TaxonIdentification> getBestTaxonIdentification(

--- a/src/main/java/eu/dissco/backend/service/ElvisService.java
+++ b/src/main/java/eu/dissco/backend/service/ElvisService.java
@@ -1,12 +1,12 @@
 package eu.dissco.backend.service;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static java.lang.Math.min;
+
 import eu.dissco.backend.domain.elvis.ElvisSpecimen;
 import eu.dissco.backend.domain.elvis.ElvisSpecimenBatchResponse;
 import eu.dissco.backend.domain.elvis.InventoryNumberSuggestion;
 import eu.dissco.backend.domain.elvis.InventoryNumberSuggestionResponse;
-import eu.dissco.backend.properties.ApplicationProperties;
 import eu.dissco.backend.repository.DigitalSpecimenRepository;
 import eu.dissco.backend.repository.ElasticSearchRepository;
 import eu.dissco.backend.schema.DigitalSpecimen;
@@ -14,7 +14,7 @@ import eu.dissco.backend.schema.TaxonIdentification;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
@@ -25,30 +25,28 @@ public class ElvisService {
 
   private final DigitalSpecimenRepository repository;
   private final ElasticSearchRepository elasticSearchRepository;
-  private final ApplicationProperties applicationProperties;
-  private final ObjectMapper mapper;
 
   public ElvisSpecimen searchByDoi(String id) {
     var specimen = repository.getLatestSpecimenById(id);
-    return buildElvisSpecimen(specimen, applicationProperties.getBaseUrl());
+    return buildElvisSpecimen(specimen);
   }
 
-  public ElvisSpecimenBatchResponse searchBySpecimenId(String inventoryNumber, int pageNumber, int pageSize)
+  public ElvisSpecimenBatchResponse searchBySpecimenId(String inventoryNumber, int pageNumber,
+      int pageSize)
       throws IOException {
     var results = searchElastic(inventoryNumber, pageNumber, pageSize);
     return new ElvisSpecimenBatchResponse(results.getLeft(), results.getRight().stream()
-        .map(specimen -> buildElvisSpecimen(specimen, applicationProperties.getBaseUrl())).toList());
-
+        .map(ElvisService::buildElvisSpecimen).toList());
   }
 
-  public InventoryNumberSuggestionResponse suggestInventoryNumber(String inventoryNumber, int pageNumber, int pageSize)
+  public InventoryNumberSuggestionResponse suggestInventoryNumber(String inventoryNumber,
+      int pageNumber, int pageSize)
       throws IOException {
     var results = searchElastic(inventoryNumber, pageNumber, pageSize);
     var specimenList = results.getRight();
     return new InventoryNumberSuggestionResponse(results.getLeft(), specimenList.stream().map(
         specimen -> new InventoryNumberSuggestion(specimen.getDwcCollectionID(),
             specimen.getOdsPhysicalSpecimenID(), specimen.getDctermsIdentifier())).toList());
-
   }
 
   private Pair<Long, List<DigitalSpecimen>> searchElastic(String inventoryNumber, int pageNumber,
@@ -59,68 +57,81 @@ public class ElvisService {
   }
 
 
-  private static ElvisSpecimen buildElvisSpecimen(DigitalSpecimen digitalSpecimen, String url) {
-    var inventoryNumber = digitalSpecimen.getOdsPhysicalSpecimenID();
-    var identifier = digitalSpecimen.getDctermsIdentifier();
-    var collectionCode = digitalSpecimen.getDwcCollectionCode();
-    var catalogNumber = digitalSpecimen.getDwcCollectionID();
-    var institutionId = digitalSpecimen.getOdsOrganisationID();
-    var institutionCode = digitalSpecimen.getOdsOrganisationCode();
-    var basisOfRecord = digitalSpecimen.getDwcBasisOfRecord();
-    var uri = url + "/ds/" + digitalSpecimen.getId();
-    var taxonId = getBestTaxonIdentification(digitalSpecimen);
-    String scientificName = null;
-    String scientificNameAuthorship = null;
-    String specificEpithet = null;
-    String family = null;
-    String genus = null;
-    String vernacularName = null;
-    if (taxonId.isPresent()) {
-      scientificName = taxonId.get().getDwcScientificName();
-      scientificNameAuthorship = taxonId.get().getDwcScientificNameAuthorship();
-      specificEpithet = taxonId.get().getDwcSpecificEpithet();
-      family = taxonId.get().getDwcFamily();
-      genus = taxonId.get().getDwcVernacularName();
-      vernacularName = taxonId.get().getDwcVernacularName();
-    }
-    var title = buildElvisTitle(digitalSpecimen, taxonId);
-    return new ElvisSpecimen(inventoryNumber, title, identifier, collectionCode, catalogNumber,
-        institutionId,
-        institutionCode, basisOfRecord, uri, scientificName, scientificNameAuthorship,
-        specificEpithet, family, genus, vernacularName);
+  private static ElvisSpecimen buildElvisSpecimen(DigitalSpecimen digitalSpecimen) {
+    var taxonIds = getBestTaxonIdentification(digitalSpecimen);
+    String scientificName = getTaxonField(
+        taxonIds.stream().map(TaxonIdentification::getDwcScientificName));
+    String scientificNameAuthorship = getTaxonField(
+        taxonIds.stream().map(TaxonIdentification::getDwcScientificNameAuthorship));
+    String specificEpithet = getTaxonField(
+        taxonIds.stream().map(TaxonIdentification::getDwcSpecificEpithet));
+    String family = getTaxonField(taxonIds.stream().map(TaxonIdentification::getDwcFamily));
+    String genus = getTaxonField(taxonIds.stream().map(TaxonIdentification::getDwcGenus));
+    String vernacularName = getTaxonField(
+        taxonIds.stream().map(TaxonIdentification::getDwcVernacularName));
+
+    return new ElvisSpecimen(
+        digitalSpecimen.getDctermsIdentifier() == null ? "" : digitalSpecimen.getDctermsIdentifier(), // inventory number
+        buildElvisTitle(digitalSpecimen), // title
+        digitalSpecimen.getDwcCollectionCode() == null ? "": digitalSpecimen.getDwcCollectionCode(), // collection code
+        digitalSpecimen.getOdsPhysicalSpecimenID(), // catalog number
+        digitalSpecimen.getOdsOrganisationCode() == null ? "" : digitalSpecimen.getOdsOrganisationCode(), // institution code
+        digitalSpecimen.getDwcBasisOfRecord() == null ? "": digitalSpecimen.getDwcBasisOfRecord(),
+        digitalSpecimen.getDctermsIdentifier(), // uri
+        scientificName, scientificNameAuthorship, specificEpithet, family, genus, vernacularName);
   }
 
-  private static String buildElvisTitle(DigitalSpecimen digitalSpecimen,
-      Optional<TaxonIdentification> taxonId) {
-    String scientificName = "";
-    if (taxonId.isPresent()) {
-      scientificName = taxonId.get().getDwcScientificName();
+  private static String getTaxonField(Stream<String> taxonFields) {
+    var taxonList = taxonFields
+        .map(a -> a == null ? "": a)
+        .toList();
+    if (taxonList.isEmpty()){
+      return "";
     }
-    // Todo - how to return blanks?
-    return scientificName + " " + digitalSpecimen.getOdsOrganisationCode() + "-"
-        + digitalSpecimen.getDwcCollectionCode() + "-" + digitalSpecimen.getDwcCollectionID();
+    var listAsString = String.join(", ", taxonList.subList(0, min(taxonList.size(), 2)));
+    if (taxonList.size() > 2) {
+      listAsString = listAsString + ", and " + (taxonList.size()-2) + " more";
+    }
+    return listAsString;
   }
 
-  private static Optional<TaxonIdentification> getBestTaxonIdentification(
+  private static String buildElvisTitle(DigitalSpecimen digitalSpecimen) {
+    var title = new StringBuilder();
+    if (digitalSpecimen.getOdsSpecimenName() != null) {
+      title.append(digitalSpecimen.getOdsSpecimenName()).append(" ");
+    }
+    if (digitalSpecimen.getOdsOrganisationCode() != null) {
+      title.append(digitalSpecimen.getOdsOrganisationCode()).append("-");
+    }
+    if (digitalSpecimen.getDwcCollectionCode() != null) {
+      title.append(digitalSpecimen.getDwcCollectionCode()).append("-");
+    }
+    title
+        .append(digitalSpecimen.getOdsPhysicalSpecimenID())
+        .append(", ")
+        .append(digitalSpecimen.getOdsOrganisationName());
+    return title.toString().replace("--", "");
+  }
+
+  private static List<TaxonIdentification> getBestTaxonIdentification(
       DigitalSpecimen digitalSpecimen) {
     if (digitalSpecimen.getOdsHasIdentifications().isEmpty()
         || digitalSpecimen.getOdsHasIdentifications().get(0).getOdsHasTaxonIdentifications()
         .isEmpty()) {
-      return Optional.empty();
+      return List.of();
     }
     // First, try to find accepted id
     for (var identification : digitalSpecimen.getOdsHasIdentifications()) {
       if (Boolean.TRUE.equals(identification.getOdsIsVerifiedIdentification())) {
         if (identification.getOdsHasTaxonIdentifications().isEmpty()) {
-          return Optional.empty();
+          return List.of();
         } else {
-          return Optional.of(identification.getOdsHasTaxonIdentifications().get(0));
+          return (identification.getOdsHasTaxonIdentifications());
         }
       }
     }
     // If no accepted id, take the first
-    return Optional.of(
-        digitalSpecimen.getOdsHasIdentifications().get(0).getOdsHasTaxonIdentifications().get(0));
+    return digitalSpecimen.getOdsHasIdentifications().get(0).getOdsHasTaxonIdentifications();
   }
 
 

--- a/src/main/java/eu/dissco/backend/service/ElvisService.java
+++ b/src/main/java/eu/dissco/backend/service/ElvisService.java
@@ -51,7 +51,7 @@ public class ElvisService {
       throws IOException {
     var map = Map.of(
         "ods:physicalSpecimenID.keyword", List.of("*" + inventoryNumber + "*"),
-        "dcterms:identifier.keyword", List.of("https://doi.org/" + inventoryNumber + "*"));
+        "dcterms:identifier.keyword", List.of("https://doi.org/*" + inventoryNumber + "*"));
     return elasticSearchRepository.elvisSearch(map, pageNumber, pageSize);
   }
 

--- a/src/main/java/eu/dissco/backend/service/ElvisService.java
+++ b/src/main/java/eu/dissco/backend/service/ElvisService.java
@@ -1,9 +1,9 @@
 package eu.dissco.backend.service;
 
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.domain.elvis.ElvisSpecimenBatchResponse;
 import eu.dissco.backend.domain.elvis.InventoryNumberSuggestion;
 import eu.dissco.backend.domain.elvis.InventoryNumberSuggestionResponse;
 import eu.dissco.backend.properties.ApplicationProperties;
@@ -33,14 +33,12 @@ public class ElvisService {
     return buildElvisSpecimen(specimen, applicationProperties.getBaseUrl());
   }
 
-  public JsonNode searchBySpecimenId(String inventoryNumber, int pageNumber, int pageSize)
+  public ElvisSpecimenBatchResponse searchBySpecimenId(String inventoryNumber, int pageNumber, int pageSize)
       throws IOException {
     var results = searchElastic(inventoryNumber, pageNumber, pageSize);
-    var elvisSpecimens = results.getRight().stream()
-        .map(specimen -> buildElvisSpecimen(specimen, applicationProperties.getBaseUrl())).toList();
-    return mapper.createObjectNode()
-        .put("total", results.getLeft())
-        .set("specimens", mapper.valueToTree(elvisSpecimens));
+    return new ElvisSpecimenBatchResponse(results.getLeft(), results.getRight().stream()
+        .map(specimen -> buildElvisSpecimen(specimen, applicationProperties.getBaseUrl())).toList());
+
   }
 
   public InventoryNumberSuggestionResponse suggestInventoryNumber(String inventoryNumber, int pageNumber, int pageSize)

--- a/src/test/java/eu/dissco/backend/controller/ElvisControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/ElvisControllerTest.java
@@ -1,0 +1,59 @@
+package eu.dissco.backend.controller;
+
+import static eu.dissco.backend.TestUtils.ID;
+import static eu.dissco.backend.TestUtils.PHYSICAL_ID;
+import static eu.dissco.backend.TestUtils.PREFIX;
+import static eu.dissco.backend.TestUtils.SUFFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import eu.dissco.backend.service.ElvisService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class ElvisControllerTest {
+
+  @Mock
+  private ElvisService elvisService;
+  private ElvisController elvisController;
+
+  @BeforeEach
+  void setup(){
+    elvisController = new ElvisController(elvisService);
+  }
+
+  @Test
+  void testGetSpecimenByInventoryNumber() throws Exception {
+    // When
+    var result = elvisController.getSpecimenByInventoryNumber(PHYSICAL_ID, 1,1);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void testGetSpecimenByDoi() {
+    // When
+    var result = elvisController.getSpecimenByDoi(PREFIX, SUFFIX);
+
+    // Then
+    then(elvisService).should().searchByDoi(ID);
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void testSuggestInventoryNumber() throws Exception {
+    // When
+    var result = elvisController.suggestInventoryNumber(PHYSICAL_ID, 1, 1);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+
+}

--- a/src/test/java/eu/dissco/backend/controller/ElvisControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/ElvisControllerTest.java
@@ -28,16 +28,7 @@ class ElvisControllerTest {
   }
 
   @Test
-  void testGetSpecimenByInventoryNumber() throws Exception {
-    // When
-    var result = elvisController.getSpecimenByInventoryNumber(PHYSICAL_ID, 1,1);
-
-    // Then
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-  }
-
-  @Test
-  void testGetSpecimenByDoi() {
+  void testGetSpecimenByDoi() throws Exception {
     // When
     var result = elvisController.getSpecimenByDoi(PREFIX, SUFFIX);
 

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -6,6 +6,7 @@ import static eu.dissco.backend.TestUtils.HANDLE;
 import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.ID_ALT;
 import static eu.dissco.backend.TestUtils.MAPPER;
+import static eu.dissco.backend.TestUtils.PHYSICAL_ID;
 import static eu.dissco.backend.TestUtils.PREFIX;
 import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_1;
 import static eu.dissco.backend.TestUtils.SOURCE_SYSTEM_ID_2;
@@ -160,6 +161,57 @@ class ElasticSearchRepositoryIT {
   }
 
   @Test
+  void testElvisSearchIdentifier() throws Exception {
+    // Given
+    String searchId = PREFIX + "/0";
+    var targetId = DOI + searchId + "000";
+    var targetSpecimen = givenDigitalSpecimenWrapper(targetId, PHYSICAL_ID);
+    List<DigitalSpecimen> specimenTestRecords = new ArrayList<>();
+    specimenTestRecords.add(targetSpecimen);
+    for (int i = 1; i < 10; i++) {
+      var specimen = givenDigitalSpecimenWrapper(DOI + PREFIX + "/" + i);
+      specimenTestRecords.add(specimen);
+    }
+    postDigitalSpecimens(parseToElasticFormat(specimenTestRecords));
+    var map = Map.of(
+        "ods:physicalSpecimenID.keyword", List.of("*" + searchId + "*"),
+        "dcterms:identifier.keyword", List.of(DOI + searchId + "*"));
+
+    // When
+    var result = repository.elvisSearch(map, 1, 11);
+
+    // then
+    assertThat(result.getLeft()).isEqualTo(1);
+    assertThat(result.getRight()).isEqualTo(List.of(targetSpecimen));
+  }
+
+  @Test
+  void testElvisSearchPhysicalId() throws Exception {
+    // Given
+    String searchId = PREFIX + "/0";
+    var targetId = searchId + "000";
+    var targetSpecimen = givenDigitalSpecimenWrapper(HANDLE, targetId);
+    List<DigitalSpecimen> specimenTestRecords = new ArrayList<>();
+    specimenTestRecords.add(targetSpecimen);
+    for (int i = 1; i < 10; i++) {
+      var specimen = givenDigitalSpecimenWrapper(DOI + PREFIX + "/" + i);
+      specimenTestRecords.add(specimen);
+    }
+    postDigitalSpecimens(parseToElasticFormat(specimenTestRecords));
+    var map = Map.of(
+        "ods:physicalSpecimenID.keyword", List.of("*" + searchId + "*"),
+        "dcterms:identifier.keyword", List.of(DOI + searchId + "*"));
+
+    // When
+    var result = repository.elvisSearch(map, 1, 11);
+
+    // then
+    assertThat(result.getLeft()).isEqualTo(1);
+    assertThat(result.getRight()).isEqualTo(List.of(targetSpecimen));
+  }
+
+
+  @Test
   void testGetSpecimens() throws Exception {
     // Given
     int pageNumber = 0;
@@ -225,7 +277,8 @@ class ElasticSearchRepositoryIT {
 
     // When
     var responseReceived = repository.getAggregations(
-        Map.of(SOURCE_SYSTEM_NAME.fullName(), List.of(anotherSourceSystemName)), getAggregationSet(),
+        Map.of(SOURCE_SYSTEM_NAME.fullName(), List.of(anotherSourceSystemName)),
+        getAggregationSet(),
         false);
 
     // Then

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -175,7 +175,7 @@ class ElasticSearchRepositoryIT {
     postDigitalSpecimens(parseToElasticFormat(specimenTestRecords));
     var map = Map.of(
         "ods:physicalSpecimenID.keyword", List.of("*" + searchId + "*"),
-        "dcterms:identifier.keyword", List.of(DOI + searchId + "*"));
+        "dcterms:identifier.keyword", List.of(DOI + "*" + searchId + "*"));
 
     // When
     var result = repository.elvisSearch(map, 1, 11);
@@ -200,7 +200,7 @@ class ElasticSearchRepositoryIT {
     postDigitalSpecimens(parseToElasticFormat(specimenTestRecords));
     var map = Map.of(
         "ods:physicalSpecimenID.keyword", List.of("*" + searchId + "*"),
-        "dcterms:identifier.keyword", List.of(DOI + searchId + "*"));
+        "dcterms:identifier.keyword", List.of(DOI + "*" + searchId + "*"));
 
     // When
     var result = repository.elvisSearch(map, 1, 11);

--- a/src/test/java/eu/dissco/backend/service/ElvisServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/ElvisServiceTest.java
@@ -4,7 +4,6 @@ import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.PHYSICAL_ID;
 import static eu.dissco.backend.TestUtils.SANDBOX_URI;
-import static eu.dissco.backend.TestUtils.SPECIMEN_NAME;
 import static eu.dissco.backend.TestUtils.givenDigitalSpecimenWrapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -12,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 
 import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.domain.elvis.ElvisSpecimenBatchResponse;
 import eu.dissco.backend.properties.ApplicationProperties;
 import eu.dissco.backend.repository.DigitalSpecimenRepository;
 import eu.dissco.backend.repository.ElasticSearchRepository;
@@ -66,12 +66,11 @@ class ElvisServiceTest {
   @MethodSource("specimenWithTaxonomy")
   void searchBySpecimenId(DigitalSpecimen specimen, boolean hasTaxonomy) throws Exception {
     // Given
-    given(elasticSearchRepository.search(anyMap(), anyInt(), anyInt())).willReturn(Pair.of(1L, List.of(specimen)));
+    given(elasticSearchRepository.search(anyMap(), anyInt(), anyInt())).willReturn(
+        Pair.of(1L, List.of(specimen)));
     given(applicationProperties.getBaseUrl()).willReturn(SANDBOX_URI);
     var elvisSpecimens = List.of(givenElvisSpecimen(hasTaxonomy));
-    var expected = MAPPER.createObjectNode()
-        .put("total", 1)
-        .set("specimens", MAPPER.valueToTree(elvisSpecimens));
+    var expected = new ElvisSpecimenBatchResponse(1L, elvisSpecimens);
 
     // When
     var result = elvisService.searchBySpecimenId(PHYSICAL_ID, 1, 1);
@@ -96,7 +95,8 @@ class ElvisServiceTest {
         }
         """
     );
-    given(elasticSearchRepository.search(anyMap(), anyInt(), anyInt())).willReturn(Pair.of(1L, List.of(givenDigitalSpecimenWrapper(ID))));
+    given(elasticSearchRepository.search(anyMap(), anyInt(), anyInt())).willReturn(
+        Pair.of(1L, List.of(givenDigitalSpecimenWrapper(ID))));
 
     // When
     var result = elvisService.suggestInventoryNumber(PHYSICAL_ID, 1, 1);
@@ -106,7 +106,7 @@ class ElvisServiceTest {
 
   }
 
-  private static Stream<Arguments> specimenWithTaxonomy(){
+  private static Stream<Arguments> specimenWithTaxonomy() {
     return Stream.of(
         Arguments.of(
             givenDigitalSpecimenWrapper(ID)
@@ -135,13 +135,15 @@ class ElvisServiceTest {
 
   private static ElvisSpecimen givenElvisSpecimen(boolean hasTaxonomy) {
     if (hasTaxonomy) {
+      var title = null + " " + null + "-" + null + "-" + null;
       return new ElvisSpecimen(
-          PHYSICAL_ID, SPECIMEN_NAME, ID, null, null, "https://ror.org/0349vqz63", null,
+          PHYSICAL_ID, title, ID, null, null, "https://ror.org/0349vqz63", null,
           null, SANDBOX_URI + "/ds/" + ID, null, null, null, "family", null, null
       );
     }
+    var title = " " + null + "-" + null + "-" + null;
     return new ElvisSpecimen(
-        PHYSICAL_ID, SPECIMEN_NAME, ID, null, null, "https://ror.org/0349vqz63", null,
+        PHYSICAL_ID, title, ID, null, null, "https://ror.org/0349vqz63", null,
         null, SANDBOX_URI + "/ds/" + ID, null, null, null, null, null, null);
   }
 

--- a/src/test/java/eu/dissco/backend/service/ElvisServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/ElvisServiceTest.java
@@ -118,7 +118,7 @@ class ElvisServiceTest {
     );
     var paramMap = Map.of(
         "ods:physicalSpecimenID.keyword", List.of("*" + PHYSICAL_ID + "*"),
-        "dcterms:identifier.keyword", List.of(DOI + PHYSICAL_ID + "*"));
+        "dcterms:identifier.keyword", List.of(DOI +"*" + PHYSICAL_ID + "*"));
 
     given(elasticSearchRepository.elvisSearch(eq(paramMap), anyInt(), anyInt())).willReturn(
         Pair.of(1L, List.of(givenDigitalSpecimenWrapper(ID))));

--- a/src/test/java/eu/dissco/backend/service/ElvisServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/ElvisServiceTest.java
@@ -1,0 +1,149 @@
+package eu.dissco.backend.service;
+
+import static eu.dissco.backend.TestUtils.ID;
+import static eu.dissco.backend.TestUtils.MAPPER;
+import static eu.dissco.backend.TestUtils.PHYSICAL_ID;
+import static eu.dissco.backend.TestUtils.SANDBOX_URI;
+import static eu.dissco.backend.TestUtils.SPECIMEN_NAME;
+import static eu.dissco.backend.TestUtils.givenDigitalSpecimenWrapper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.BDDMockito.given;
+
+import eu.dissco.backend.domain.elvis.ElvisSpecimen;
+import eu.dissco.backend.properties.ApplicationProperties;
+import eu.dissco.backend.repository.DigitalSpecimenRepository;
+import eu.dissco.backend.repository.ElasticSearchRepository;
+import eu.dissco.backend.schema.DigitalSpecimen;
+import eu.dissco.backend.schema.Identification;
+import eu.dissco.backend.schema.TaxonIdentification;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElvisServiceTest {
+
+  @Mock
+  private DigitalSpecimenRepository repository;
+  @Mock
+  private ElasticSearchRepository elasticSearchRepository;
+  @Mock
+  private ApplicationProperties applicationProperties;
+
+  private ElvisService elvisService;
+
+  @BeforeEach
+  void setup() {
+    elvisService = new ElvisService(repository, elasticSearchRepository, applicationProperties,
+        MAPPER);
+  }
+
+  @Test
+  void testSearchByDoi() {
+    // Given
+    given(repository.getLatestSpecimenById(ID)).willReturn(givenDigitalSpecimenWrapper(ID));
+    given(applicationProperties.getBaseUrl()).willReturn(SANDBOX_URI);
+    var expected = givenElvisSpecimen(false);
+
+    // When
+    var result = elvisService.searchByDoi(ID);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("specimenWithTaxonomy")
+  void searchBySpecimenId(DigitalSpecimen specimen, boolean hasTaxonomy) throws Exception {
+    // Given
+    given(elasticSearchRepository.search(anyMap(), anyInt(), anyInt())).willReturn(Pair.of(1L, List.of(specimen)));
+    given(applicationProperties.getBaseUrl()).willReturn(SANDBOX_URI);
+    var elvisSpecimens = List.of(givenElvisSpecimen(hasTaxonomy));
+    var expected = MAPPER.createObjectNode()
+        .put("total", 1)
+        .set("specimens", MAPPER.valueToTree(elvisSpecimens));
+
+    // When
+    var result = elvisService.searchBySpecimenId(PHYSICAL_ID, 1, 1);
+
+    // Then
+    assertThat(MAPPER.writeValueAsString(result)).isEqualTo(MAPPER.writeValueAsString(expected));
+  }
+
+  @Test
+  void testSuggestInventoryNumbers() throws Exception {
+    // Given
+    var expected = MAPPER.readTree(""" 
+        {
+          "total": 1,
+          "inventoryNumbers": [
+          {
+            "catalogNumber": null,
+            "inventoryNumber":"global_id_123123",
+            "identifier":"20.5000.1025/ABC-123-XYZ"
+          }
+          ]
+        }
+        """
+    );
+    given(elasticSearchRepository.search(anyMap(), anyInt(), anyInt())).willReturn(Pair.of(1L, List.of(givenDigitalSpecimenWrapper(ID))));
+
+    // When
+    var result = elvisService.suggestInventoryNumber(PHYSICAL_ID, 1, 1);
+
+    // Then
+    assertThat(MAPPER.writeValueAsString(result)).isEqualTo(MAPPER.writeValueAsString(expected));
+
+  }
+
+  private static Stream<Arguments> specimenWithTaxonomy(){
+    return Stream.of(
+        Arguments.of(
+            givenDigitalSpecimenWrapper(ID)
+                .withOdsHasIdentifications(List.of(
+                    new Identification()
+                        .withOdsIsVerifiedIdentification(true)
+                        .withOdsHasTaxonIdentifications(List.of(new TaxonIdentification()
+                            .withDwcFamily("family"))))), true
+        ),
+        Arguments.of(
+            givenDigitalSpecimenWrapper(ID)
+                .withOdsHasIdentifications(List.of(
+                    new Identification()
+                        .withOdsIsVerifiedIdentification(false)
+                        .withOdsHasTaxonIdentifications(List.of(new TaxonIdentification()
+                            .withDwcFamily("family"))))), true
+        ),
+        Arguments.of(
+            givenDigitalSpecimenWrapper(ID)
+                .withOdsHasIdentifications(List.of(
+                    new Identification()
+                        .withOdsHasTaxonIdentifications(List.of()))), false)
+
+    );
+  }
+
+  private static ElvisSpecimen givenElvisSpecimen(boolean hasTaxonomy) {
+    if (hasTaxonomy) {
+      return new ElvisSpecimen(
+          PHYSICAL_ID, SPECIMEN_NAME, ID, null, null, "https://ror.org/0349vqz63", null,
+          null, SANDBOX_URI + "/ds/" + ID, null, null, null, "family", null, null
+      );
+    }
+    return new ElvisSpecimen(
+        PHYSICAL_ID, SPECIMEN_NAME, ID, null, null, "https://ror.org/0349vqz63", null,
+        null, SANDBOX_URI + "/ds/" + ID, null, null, null, null, null, null);
+  }
+
+
+}


### PR DESCRIPTION
Adds ELViS endpoints

`/elvis/specimen/{prefix}/{suffix}` -> Given a DOI, retrieves exactly one specimen according to ELViS specifications
`/elvis/specimen/suggest/inventoryNumber` -> conducts wildcard search (i.e. a partial match) on provided searchValue. Checks input against `ods:physicalSpecimenID` and `dcterms:identifier` (doi)

[openAPI specification](https://github.com/user-attachments/files/18493413/api-docs.txt) shows schema and describes the mapping from openDS (see specifically the `elvis-controller`). 

