### PR TITLE
Elastic Search Improvements - Wildcard support, documentation, adds "habitat" search term

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,16 +1,4 @@
-# October 14 2024
-# Issue in Spring OpenFeign, Need to upgrade commons-io to version 2.14.0
-CVE-2024-47554
-
-# Nov 13
-# Issue with spring-starter-webflux
-CVE-2024-47535
-
-# Feb 14
-# Issue with Alpine
-CVE-2024-12797
-
-# Issue with Spring boot
-CVE-2025-24970
-CVE-2025-24970
-CVE-2024-57699
+# March 18
+# Issues with Alpine
+CVE-2024-8176
+CVE-2025-0840

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,3 +2,7 @@
 # Issues with Alpine
 CVE-2024-8176
 CVE-2025-0840
+
+# March 18
+# Dependency managed by Spring Boot
+CVE-2024-47554

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -260,7 +260,29 @@ public class DigitalSpecimenController extends BaseController {
   @Operation(
       summary = "Search for digital specimen",
       description = """
-          Accepts key-value pairs of search parameters. Terms are mapped to the OpenDS standard.
+          Accepts key-value pairs of search parameters. Available search terms (literal):
+          * country
+          * countryCode
+          * midsLevel
+          * physicalSpecimenId
+          * typeStatus
+          * organisatonID
+          * organisationName
+          * sourceSystemID
+          * sourceSystemName
+          * specimenName
+          * datasetName
+          * collectionCode
+          * identifiedBy
+          * basisOfRecord
+          * livingOrPreserved
+          * habitat
+          
+          Additionally, a free text query can be provided: q={some query string}
+          
+          An example of a combined parameter and free text query: /search?q=Sabellaria+bellis&topicDiscipline=Zoology&midsLevel=1
+          
+          Wildcards are supported: "*"
           """
   )
   @ApiResponses(value = {

--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -264,7 +264,7 @@ public class DigitalSpecimenController extends BaseController {
           * country
           * countryCode
           * midsLevel
-          * physicalSpecimenId
+          * physicalSpecimenID
           * typeStatus
           * organisatonID
           * organisationName

--- a/src/main/java/eu/dissco/backend/domain/DefaultMappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/DefaultMappingTerms.java
@@ -11,7 +11,8 @@ public enum DefaultMappingTerms implements MappingTerm {
   COUNTRY("country", "ods:hasEvents.ods:hasLocation.dwc:country.keyword"),
   COUNTRY_CODE("countryCode", "ods:hasEvents.ods:hasLocation.dwc:countryCode.keyword"),
   MIDS_LEVEL("midsLevel", "ods:midsLevel"),
-  PHYSICAL_SPECIMEN_ID("physicalSpecimenId", "ods:physicalSpecimenID.keyword"),
+  PHYSICAL_SPECIMEN_ID_DEPRECATED("physicalSpecimenId", "ods:physicalSpecimenID.keyword"),
+  PHYSICAL_SPECIMEN_ID("physicalSpecimenID", "ods:physicalSpecimenID.keyword"),
   TYPE_STATUS("typeStatus", "ods:hasIdentifications.dwc:typeStatus.keyword"),
   LICENSE("license", "dcterms:license.keyword"),
   HAS_MEDIA("hasMedia", "ods:isKnownToContainMedia"),
@@ -75,6 +76,7 @@ public enum DefaultMappingTerms implements MappingTerm {
     paramMap.put(COUNTRY.requestName, COUNTRY);
     paramMap.put(COUNTRY_CODE.requestName, COUNTRY_CODE);
     paramMap.put(MIDS_LEVEL.requestName, MIDS_LEVEL);
+    paramMap.put(PHYSICAL_SPECIMEN_ID_DEPRECATED.requestName, PHYSICAL_SPECIMEN_ID_DEPRECATED);
     paramMap.put(PHYSICAL_SPECIMEN_ID.requestName, PHYSICAL_SPECIMEN_ID);
     paramMap.put(TYPE_STATUS.requestName, TYPE_STATUS);
     paramMap.put(LICENSE.requestName, LICENSE);

--- a/src/main/java/eu/dissco/backend/domain/DefaultMappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/DefaultMappingTerms.java
@@ -25,8 +25,8 @@ public enum DefaultMappingTerms implements MappingTerm {
   COLLECTION_ID("collectionID", "dwc:collectionID.keyword"),
   IDENTIFIED_BY("identifiedBy", "ods:hasIdentifications.ods:hasAgents.schema:name.keyword"),
   BASIS_OF_RECORD("basisOfRecord", "dwc:basisOfRecord.keyword"),
-  LIVING_OR_PRESERVED("livingOrPreserved", "ods:livingOrPreserved.keyword"),
-  TOPIC_DISCIPLINE("topicDiscipline", "ods:topicDiscipline.keyword"),
+  LIVING_OR_PRESERVED("livingOrPreserved", "ods:livingOrPreserved"),
+  TOPIC_DISCIPLINE("topicDiscipline", "ods:topicDiscipline"),
   HABITAT("habitat", "ods:hasEvents.dwc:habitat.keyword"),
   QUERY("q", "q");
 
@@ -91,6 +91,7 @@ public enum DefaultMappingTerms implements MappingTerm {
     paramMap.put(COLLECTION_CODE.requestName, COLLECTION_CODE);
     paramMap.put(IDENTIFIED_BY.requestName, IDENTIFIED_BY);
     paramMap.put(COLLECTION_ID.requestName, COLLECTION_ID);
+    paramMap.put(HABITAT.requestName, HABITAT);
     paramMap.put(QUERY.requestName, QUERY);
     paramMap.putAll(TaxonMappingTerms.getTaxonMapping());
     return paramMap;

--- a/src/main/java/eu/dissco/backend/domain/DefaultMappingTerms.java
+++ b/src/main/java/eu/dissco/backend/domain/DefaultMappingTerms.java
@@ -25,8 +25,9 @@ public enum DefaultMappingTerms implements MappingTerm {
   COLLECTION_ID("collectionID", "dwc:collectionID.keyword"),
   IDENTIFIED_BY("identifiedBy", "ods:hasIdentifications.ods:hasAgents.schema:name.keyword"),
   BASIS_OF_RECORD("basisOfRecord", "dwc:basisOfRecord.keyword"),
-  LIVING_OR_PRESERVED("livingOrPreserved", "ods:livingOrPreserved"),
-  TOPIC_DISCIPLINE("topicDiscipline", "ods:topicDiscipline"),
+  LIVING_OR_PRESERVED("livingOrPreserved", "ods:livingOrPreserved.keyword"),
+  TOPIC_DISCIPLINE("topicDiscipline", "ods:topicDiscipline.keyword"),
+  HABITAT("habitat", "ods:hasEvents.dwc:habitat.keyword"),
   QUERY("q", "q");
 
 

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -117,6 +117,8 @@ class ElasticSearchRepositoryIT {
     return Stream.of(
         Arguments.of("ods:physicalSpecimenID.keyword", "global_id_45634",
             1L),
+        Arguments.of("ods:physicalSpecimenID.keyword", "global_id_45*",
+            1L),
         Arguments.of("q", PREFIX + "/0", 10L)
     );
   }


### PR DESCRIPTION
**Changes**
- In the swagger endpoint, documents which terms are searchable in the /search endpoint
- makes "habitat" searchable (request from Senckenberg)
- Adds wildcard support


**Issue**: Search term "physicalSpecimenId" doesn't follow our naming convention. I could change this to "physicalSpecimenID", but I suspect that would affect the front end. I could create a redundant term, and support both physId and physID for a while, but we'd need to remember to remove the "Id" term later. 

**Issue**: we should make more terms searchable. I'm sure there's a way to leverage our json schemas some way to get a full list of terms and json paths instead of hardcoding terms. 

