### PR TITLE
Mjr endpoint needs to be authenticated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.3</version>
+    <version>3.4.4</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/backend/security/WebSecurityConfig.java
+++ b/src/main/java/eu/dissco/backend/security/WebSecurityConfig.java
@@ -22,6 +22,7 @@ public class WebSecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
         .requestMatchers(EndpointRequest.to(HealthEndpoint.class)).permitAll()
+        .requestMatchers(HttpMethod.GET, "/mjr/v1/creator").authenticated()
         .requestMatchers(HttpMethod.GET, "**").permitAll()
         .anyRequest().authenticated());
 


### PR DESCRIPTION
Asserts clients using `/mjr/v1/creator` are authenticated. This prevents a 500 error if the user is unauthenticated (would have thrown a NPE otherwise). 