### PR TITLE
Uses ER to get media ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>

--- a/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/AnnotationRepository.java
@@ -59,6 +59,14 @@ public class AnnotationRepository {
         .fetch(this::mapToAnnotation);
   }
 
+  public List<Annotation> getForTargets(List<String> ids){
+    return context.select(ANNOTATION.DATA)
+        .from(ANNOTATION)
+        .where(ANNOTATION.TARGET_ID.in(ids))
+        .and(ANNOTATION.TOMBSTONED.isNull())
+        .fetch(this::mapToAnnotation);
+  }
+
   private Annotation mapToAnnotation(Record dbRecord) {
     try {
       return mapper.readValue(dbRecord.get(ANNOTATION.DATA).data(),

--- a/src/main/java/eu/dissco/backend/repository/DigitalMediaRepository.java
+++ b/src/main/java/eu/dissco/backend/repository/DigitalMediaRepository.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.jooq.Record;
-import org.jooq.Record1;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -36,25 +35,18 @@ public class DigitalMediaRepository {
         .offset(offset).limit(pageSizePlusOne).fetch(this::mapToMultiMediaObject);
   }
 
+  public List<DigitalMedia> getLatestDigitalMediaObjectsById(List<String> ids) {
+    return context.select(DIGITAL_MEDIA_OBJECT.asterisk())
+        .from(DIGITAL_MEDIA_OBJECT)
+        .where(DIGITAL_MEDIA_OBJECT.ID.in(ids))
+        .fetch(this::mapToMultiMediaObject);
+  }
+
   public DigitalMedia getLatestDigitalMediaObjectById(String id) {
     return context.select(DIGITAL_MEDIA_OBJECT.asterisk())
         .from(DIGITAL_MEDIA_OBJECT)
         .where(DIGITAL_MEDIA_OBJECT.ID.eq(id))
         .fetchOne(this::mapToMultiMediaObject);
-  }
-
-  public List<DigitalMedia> getDigitalMediaForSpecimen(String id) {
-    return context.select(DIGITAL_MEDIA_OBJECT.asterisk())
-        .from(DIGITAL_MEDIA_OBJECT)
-        .where(DIGITAL_MEDIA_OBJECT.DIGITAL_SPECIMEN_ID.eq(id))
-        .fetch(this::mapToMultiMediaObject);
-  }
-
-  public List<String> getDigitalMediaIdsForSpecimen(String id) {
-    return context.select(DIGITAL_MEDIA_OBJECT.ID)
-        .from(DIGITAL_MEDIA_OBJECT)
-        .where(DIGITAL_MEDIA_OBJECT.DIGITAL_SPECIMEN_ID.eq(id))
-        .fetch(Record1::value1);
   }
 
   public JsonNode getMediaOriginalData(String id) {

--- a/src/main/java/eu/dissco/backend/service/DigitalMediaService.java
+++ b/src/main/java/eu/dissco/backend/service/DigitalMediaService.java
@@ -77,7 +77,8 @@ public class DigitalMediaService {
       throws JsonProcessingException, NotFoundException {
     var digitalMediaNode = mongoRepository.getByVersion(id, version, "digital_media_provenance");
     var digitalMedia = mapResultToDigitalMedia(digitalMediaNode);
-    var dataNode = new JsonApiData(digitalMedia.getDctermsIdentifier(), FdoType.DIGITAL_MEDIA.getName(), digitalMedia,
+    var dataNode = new JsonApiData(digitalMedia.getDctermsIdentifier(),
+        FdoType.DIGITAL_MEDIA.getName(), digitalMedia,
         mapper);
     return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
   }
@@ -93,20 +94,20 @@ public class DigitalMediaService {
 
   // Used By Other Services
   public List<DigitalMediaFull> getFullDigitalMediaFromSpecimen(DigitalSpecimen specimen) {
-    var mediaIds =getMediaIdsFromSpecimen(specimen);
+    var mediaIds = getMediaIdsFromSpecimen(specimen);
     var digitalMedias = repository.getLatestDigitalMediaObjectsById(mediaIds);
     var annotationsForMedia = annotationService.getAnnotationForTargetObjects(mediaIds);
     return digitalMedias.stream().map(digitalMedia -> {
-          var annotations = annotationsForMedia.get(digitalMedia.getDctermsIdentifier());
-          return new DigitalMediaFull(digitalMedia, annotations);
-        }).toList();
+      var annotations = annotationsForMedia.get(digitalMedia.getDctermsIdentifier());
+      return new DigitalMediaFull(digitalMedia, annotations);
+    }).toList();
   }
 
-  public List<DigitalMedia> getDigitalMediaFromSpecimen(DigitalSpecimen specimen){
+  public List<DigitalMedia> getDigitalMediaFromSpecimen(DigitalSpecimen specimen) {
     return repository.getLatestDigitalMediaObjectsById(getMediaIdsFromSpecimen(specimen));
   }
 
-  private static List<String> getMediaIdsFromSpecimen(DigitalSpecimen specimen){
+  private static List<String> getMediaIdsFromSpecimen(DigitalSpecimen specimen) {
     return specimen.getOdsHasEntityRelationships().stream()
         .filter(er -> er.getDwcRelationshipOfResource().equalsIgnoreCase("hasDigitalMedia"))
         .map(er -> er.getDwcRelatedResourceID().replace(DOI_STRING, ""))
@@ -159,13 +160,13 @@ public class DigitalMediaService {
       String path, String orcid)
       throws PidCreationException, ConflictException, NotFoundException {
     var digitalMedia = repository.getLatestDigitalMediaObjectById(id);
-    if (digitalMedia == null){
+    if (digitalMedia == null) {
       log.error("Unable to find media with id {}", id);
       throw new NotFoundException("Specimen " + id + " not found");
     }
     var digitalSpecimen = digitalSpecimenRepository.getLatestSpecimenById(
         getDsDoiFromDmo(digitalMedia));
-    if (digitalSpecimen == null){
+    if (digitalSpecimen == null) {
       log.error("Unable to find specimen for media with id {}", id);
       throw new NotFoundException("Unable to find related specimen for media with id " + id);
     }

--- a/src/main/java/eu/dissco/backend/service/DigitalSpecimenService.java
+++ b/src/main/java/eu/dissco/backend/service/DigitalSpecimenService.java
@@ -123,7 +123,7 @@ public class DigitalSpecimenService {
   }
 
   private JsonApiWrapper mapFullSpecimen(String id, String path, DigitalSpecimen specimen) {
-    var digitalMedia = digitalMediaService.getDigitalMediaObjectFull(id);
+    var digitalMedia = digitalMediaService.getFullDigitalMediaFromSpecimen(specimen);
     var annotation = annotationService.getAnnotationForTargetObject(id);
     var attributeNode = mapper.valueToTree(
         new DigitalSpecimenFull(specimen, digitalMedia, annotation));
@@ -152,8 +152,15 @@ public class DigitalSpecimenService {
   }
 
   public JsonApiListResponseWrapper getDigitalMedia(String id, String path) {
-    var dataNode = digitalMediaService.getDigitalMediaForSpecimen(id);
-    return new JsonApiListResponseWrapper(dataNode, new JsonApiLinksFull(path));
+    var specimen = repository.getLatestSpecimenById(id);
+    var digitalMedias = digitalMediaService.getDigitalMediaFromSpecimen(specimen);
+    var dataNodes =
+        digitalMedias.stream()
+            .map(media -> new JsonApiData(
+                media.getId(), FdoType.DIGITAL_MEDIA.getName(), media, mapper
+            ))
+            .toList();
+    return new JsonApiListResponseWrapper(dataNodes, new JsonApiLinksFull(path));
   }
 
   private DigitalSpecimen mapResultToSpecimen(JsonNode result)

--- a/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/AnnotationRepositoryIT.java
@@ -6,6 +6,7 @@ import static eu.dissco.backend.TestUtils.ID_ALT;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.PREFIX;
+import static eu.dissco.backend.TestUtils.TARGET_ID;
 import static eu.dissco.backend.TestUtils.USER_ID_TOKEN;
 import static eu.dissco.backend.database.jooq.Tables.ANNOTATION;
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationResponse;
@@ -73,6 +74,19 @@ class AnnotationRepositoryIT extends BaseRepositoryIT {
 
     // Then
     assertThat(receivedResponse).hasSameElementsAs(annotationsAll);
+  }
+
+  @Test
+  void testGetAnnotationsForTargets() throws JsonProcessingException {
+    // Given
+    var annotations = List.of(givenAnnotationResponse(), givenAnnotationResponse(ID_ALT, ORCID, "2"));
+    postAnnotations(annotations);
+
+    // When
+    var result = repository.getForTargets(List.of(TARGET_ID, "2"));
+
+    // Then
+    assertThat(result).hasSameElementsAs(annotations);
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/DigitalMediaRepositoryIT.java
@@ -87,47 +87,6 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetDigitalMediaForSpecimen() throws JsonProcessingException {
-    // Given
-    String specimenId = ID_ALT;
-    List<DigitalMedia> postedMediaObjects = List.of(
-        givenDigitalMediaObject(ID, specimenId),
-        givenDigitalMediaObject("aa", specimenId));
-    postMediaObjects(postedMediaObjects);
-
-    var specimen = givenDigitalSpecimenWrapper(specimenId);
-    postDigitalSpecimen(specimen);
-
-    // When
-    var receivedResponse = repository.getDigitalMediaForSpecimen(specimenId);
-
-    // Then
-    assertThat(receivedResponse).hasSameElementsAs(
-        List.of(
-            givenDigitalMediaObject(DOI + ID, specimenId),
-            givenDigitalMediaObject(DOI + "aa", specimenId)));
-  }
-
-  @Test
-  void testGetDigitalMediaIdsForSpecimen() throws JsonProcessingException {
-    // Given
-    List<String> expectedResponse = List.of(ID, ID_ALT);
-    String specimenId = "specimenId";
-    var specimen = givenDigitalSpecimenWrapper(specimenId);
-    postDigitalSpecimen(specimen);
-    List<DigitalMedia> mediaObjects = List.of(
-        givenDigitalMediaObject(ID, specimenId),
-        givenDigitalMediaObject(ID_ALT, specimenId));
-    postMediaObjects(mediaObjects);
-
-    // When
-    var receivedResponse = repository.getDigitalMediaIdsForSpecimen(specimenId);
-
-    // Then
-    assertThat(receivedResponse).hasSameElementsAs(expectedResponse);
-  }
-
-  @Test
   void testGetOriginalMediaData() throws JsonProcessingException{
     // Given
     var expected = MAPPER.createObjectNode()

--- a/src/test/java/eu/dissco/backend/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/DigitalMediaRepositoryIT.java
@@ -4,6 +4,7 @@ import static eu.dissco.backend.TestUtils.DOI;
 import static eu.dissco.backend.TestUtils.ID;
 import static eu.dissco.backend.TestUtils.ID_ALT;
 import static eu.dissco.backend.TestUtils.MAPPER;
+import static eu.dissco.backend.TestUtils.TARGET_ID;
 import static eu.dissco.backend.TestUtils.givenDigitalSpecimenWrapper;
 import static eu.dissco.backend.database.jooq.Tables.DIGITAL_MEDIA_OBJECT;
 import static eu.dissco.backend.database.jooq.Tables.DIGITAL_SPECIMEN;
@@ -17,12 +18,14 @@ import eu.dissco.backend.schema.DigitalMedia;
 import eu.dissco.backend.schema.DigitalSpecimen;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.jooq.JSONB;
 import org.jooq.Query;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@Slf4j
 class DigitalMediaRepositoryIT extends BaseRepositoryIT {
 
   private DigitalMediaRepository repository;
@@ -75,8 +78,6 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
     var secondMediaObject = givenDigitalMediaObject(ID, ID_ALT, 2);
 
     postMediaObjects(List.of(firstMediaObject, secondMediaObject));
-    var specimen = givenDigitalSpecimenWrapper(ID_ALT);
-    postDigitalSpecimen(specimen);
 
     // When
     var receivedResponse = repository.getLatestDigitalMediaObjectById(ID);
@@ -87,7 +88,21 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testGetOriginalMediaData() throws JsonProcessingException{
+  void testGetLatestDigitalMediaObjectsById() throws JsonProcessingException {
+    var expected = List.of(givenDigitalMediaObject(DOI + ID, TARGET_ID),
+        givenDigitalMediaObject(DOI + ID_ALT, TARGET_ID));
+    postMediaObjects(List.of(givenDigitalMediaObject(ID, TARGET_ID),
+        givenDigitalMediaObject(ID_ALT, TARGET_ID)));
+
+    // When
+    var receivedResponse = repository.getLatestDigitalMediaObjectsById(List.of(ID, ID_ALT));
+
+    // Then
+    assertThat(receivedResponse).hasSameElementsAs(expected);
+  }
+
+  @Test
+  void testGetOriginalMediaData() throws JsonProcessingException {
     // Given
     var expected = MAPPER.createObjectNode()
         .put("originalData", "yep");

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -3,6 +3,7 @@ package eu.dissco.backend.service;
 import static eu.dissco.backend.TestUtils.CREATED;
 import static eu.dissco.backend.TestUtils.DOI;
 import static eu.dissco.backend.TestUtils.ID;
+import static eu.dissco.backend.TestUtils.ID_ALT;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.PREFIX;
@@ -45,6 +46,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
@@ -140,6 +142,24 @@ class AnnotationServiceTest {
 
     // Then
     assertThat(received).isEqualTo(expected);
+  }
+
+  @Test
+  void testGetAnnotationForTargetObjects() {
+    // Given
+    var expected = Map.of(
+        ID, List.of(givenAnnotationResponse("1", ORCID, ID)),
+        ID_ALT, List.of(givenAnnotationResponse("2", ORCID, ID_ALT))
+    );
+    given(repository.getForTargets(List.of(DOI + ID, DOI + ID_ALT))).willReturn(List.of(
+        givenAnnotationResponse("1", ORCID, ID),
+        givenAnnotationResponse("2", ORCID, ID_ALT)));
+
+    // When
+    var result = service.getAnnotationForTargetObjects(List.of(ID, ID_ALT));
+
+    // Then
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
@@ -306,7 +326,8 @@ class AnnotationServiceTest {
   void testUpdateAnnotation() throws Exception {
     // Given
     var expected = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH, ORCID);
-    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(
+        Optional.of(givenAnnotationResponse()));
     var kafkaResponse = MAPPER.valueToTree(givenAnnotationResponse());
     given(annotationClient.updateAnnotation(any(), any(), any()))
         .willReturn(kafkaResponse);
@@ -374,7 +395,8 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotation() throws Exception {
     // Given
-    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotation(ID, ORCID)).willReturn(
+        Optional.of(givenAnnotationResponse()));
 
     // When
     var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), false);
@@ -386,7 +408,8 @@ class AnnotationServiceTest {
   @Test
   void testTombstoneAnnotationAmin() throws Exception {
     // Given
-    given(repository.getActiveAnnotation(ID, null)).willReturn(Optional.of(givenAnnotationResponse()));
+    given(repository.getActiveAnnotation(ID, null)).willReturn(
+        Optional.of(givenAnnotationResponse()));
 
     // When
     var result = service.tombstoneAnnotation(PREFIX, SUFFIX, givenAgent(), true);

--- a/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
@@ -15,7 +15,6 @@ import static eu.dissco.backend.domain.DefaultMappingTerms.TOPIC_DISCIPLINE;
 import static eu.dissco.backend.utils.AnnotationUtils.ANNOTATION_PATH;
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationJsonResponseNoPagination;
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationResponse;
-import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaJsonApiData;
 import static eu.dissco.backend.utils.DigitalMediaObjectUtils.givenDigitalMediaObject;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasJobRequest;
 import static eu.dissco.backend.utils.MachineAnnotationServiceUtils.givenMasResponse;
@@ -199,7 +198,7 @@ class DigitalSpecimenServiceTest {
     var digitalMedia = List.of(new DigitalMediaFull(givenDigitalMediaObject(ID), List.of()));
     var annotations = List.of(givenAnnotationResponse(USER_ID_TOKEN, ID));
     given(repository.getLatestSpecimenById(ID)).willReturn(digitalSpecimen);
-    given(digitalMediaService.getDigitalMediaObjectFull(ID)).willReturn(digitalMedia);
+    given(digitalMediaService.getFullDigitalMediaFromSpecimen(digitalSpecimen)).willReturn(digitalMedia);
     given(annotationService.getAnnotationForTargetObject(ID)).willReturn(annotations);
     var attributeNode = MAPPER.valueToTree(
         new DigitalSpecimenFull(digitalSpecimen,
@@ -226,7 +225,7 @@ class DigitalSpecimenServiceTest {
     var annotations = List.of(givenAnnotationResponse(USER_ID_TOKEN, ID));
     given(mongoRepository.getByVersion(ID, version, "digital_specimen_provenance")).willReturn(
         specimen);
-    given(digitalMediaService.getDigitalMediaObjectFull(ID)).willReturn(digitalMedia);
+    given(digitalMediaService.getFullDigitalMediaFromSpecimen(any())).willReturn(digitalMedia);
     given(annotationService.getAnnotationForTargetObject(ID)).willReturn(annotations);
     var digitalSpecimenWrapper = givenDigitalSpecimenWrapper(DOI + ID, "123", version,
         SOURCE_SYSTEM_ID_1, SPECIMEN_NAME);
@@ -296,22 +295,6 @@ class DigitalSpecimenServiceTest {
 
     // When
     var result = service.getAnnotations(ID, ANNOTATION_PATH);
-
-    // Then
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  void testGetDigitalMedia() {
-    // Given
-    var digitalMedia = givenDigitalMediaJsonApiData(ID);
-    var digitalMediaList = List.of(digitalMedia);
-    var expected = new JsonApiListResponseWrapper(List.of(digitalMedia),
-        new JsonApiLinksFull(SPECIMEN_PATH));
-    given(digitalMediaService.getDigitalMediaForSpecimen(ID)).willReturn(digitalMediaList);
-
-    // When
-    var result = service.getDigitalMedia(ID, SPECIMEN_PATH);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
@@ -2,6 +2,7 @@ package eu.dissco.backend.service;
 
 import static eu.dissco.backend.TestUtils.DOI;
 import static eu.dissco.backend.TestUtils.ID;
+import static eu.dissco.backend.TestUtils.ID_ALT;
 import static eu.dissco.backend.TestUtils.MAPPER;
 import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.SANDBOX_URI;
@@ -263,6 +264,24 @@ class DigitalSpecimenServiceTest {
 
     // Then
     assertThat(responseReceived).isEqualTo(responseExpected);
+  }
+
+  @Test
+  void testGetDigitalMediaFromSpecimen(){
+    // Given
+    given(repository.getLatestSpecimenById(ID)).willReturn(givenDigitalSpecimenWrapper(ID));
+    given(digitalMediaService.getDigitalMediaFromSpecimen(givenDigitalSpecimenWrapper(ID)))
+        .willReturn(List.of(givenDigitalMediaObject(ID_ALT)));
+    var expected = new JsonApiListResponseWrapper(
+        List.of(new JsonApiData(ID_ALT, FdoType.DIGITAL_MEDIA.getName(), givenDigitalMediaObject(ID_ALT), MAPPER)),
+        new JsonApiLinksFull(SPECIMEN_PATH)
+    );
+
+    // When
+    var result = service.getDigitalMedia(ID, SPECIMEN_PATH);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
Uses ER to get media ids instead of relying on a database column (since we have the many to many relationship now)
[Jira](https://naturalis.atlassian.net/browse/DD-1643?atlOrigin=eyJpIjoiODVlNDU5ZGNiODIwNGE2ZDljZmFlYmRjZDc5NzE2ODMiLCJwIjoiaiJ9)

Not dependent on the specimen-media processor merger, this can be merged right away