### PR TITLE
Return 404 for missing objects

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/AnnotationController.java
+++ b/src/main/java/eu/dissco/backend/controller/AnnotationController.java
@@ -13,10 +13,10 @@ import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
 import eu.dissco.backend.domain.openapi.annotation.AnnotationRequest;
 import eu.dissco.backend.domain.openapi.annotation.AnnotationResponseList;
 import eu.dissco.backend.domain.openapi.annotation.AnnotationResponseSingle;
-import eu.dissco.backend.domain.openapi.shared.VersionResponse;
 import eu.dissco.backend.domain.openapi.annotation.BatchAnnotationCountRequest;
 import eu.dissco.backend.domain.openapi.annotation.BatchAnnotationCountResponse;
 import eu.dissco.backend.domain.openapi.annotation.BatchAnnotationRequest;
+import eu.dissco.backend.domain.openapi.shared.VersionResponse;
 import eu.dissco.backend.exceptions.ForbiddenException;
 import eu.dissco.backend.exceptions.InvalidAnnotationRequestException;
 import eu.dissco.backend.exceptions.NoAnnotationFoundException;
@@ -78,7 +78,7 @@ public class AnnotationController extends BaseController {
   public ResponseEntity<JsonApiWrapper> getAnnotation(
       @Parameter(description = PREFIX_OAS) @PathVariable("prefix") String prefix,
       @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix,
-      HttpServletRequest request) {
+      HttpServletRequest request) throws NotFoundException {
     var id = prefix + '/' + suffix;
     log.info("Received get request for annotationRequests: {}", id);
     var annotation = service.getAnnotation(id, getPath(request));

--- a/src/main/java/eu/dissco/backend/controller/DigitalMediaController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalMediaController.java
@@ -84,7 +84,7 @@ public class DigitalMediaController extends BaseController {
   public ResponseEntity<JsonApiWrapper> getDigitalMediaObjectById(
       @Parameter(description = PREFIX_OAS) @PathVariable("prefix") String prefix,
       @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix,
-      HttpServletRequest request) {
+      HttpServletRequest request) throws NotFoundException {
     var id = prefix + '/' + suffix;
     log.info("Received get request for multiMedia with id: {}", id);
     var multiMedia = service.getDigitalMediaById(id, getPath(request));
@@ -190,8 +190,7 @@ public class DigitalMediaController extends BaseController {
       @Parameter(description = JOB_STATUS_OAS) @RequestParam(required = false) JobState state,
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,
       @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
-      HttpServletRequest request
-  ) throws NotFoundException {
+      HttpServletRequest request) {
     var path = getPath(request);
     var id = prefix + '/' + suffix;
     return ResponseEntity.ok(

--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -105,7 +105,7 @@ public class DigitalSpecimenController extends BaseController {
   public ResponseEntity<JsonApiWrapper> getSpecimenById(
       @Parameter(description = PREFIX_OAS) @PathVariable("prefix") String prefix,
       @Parameter(description = SUFFIX_OAS) @PathVariable("suffix") String suffix,
-      HttpServletRequest request) {
+      HttpServletRequest request) throws NotFoundException {
     var id = prefix + '/' + suffix;
     log.info("Received get request for specimen with id: {}", id);
     var specimen = service.getSpecimenById(id, getPath(request));

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -54,11 +54,15 @@ public class AnnotationService {
   private final ObjectMapper mapper;
   private final MasJobRecordService masJobRecordService;
 
-  public JsonApiWrapper getAnnotation(String id, String path) {
+  public JsonApiWrapper getAnnotation(String id, String path) throws NotFoundException {
     var annotation = repository.getAnnotation(id);
-    var dataNode = new JsonApiData(id, FdoType.ANNOTATION.getName(),
-        mapper.valueToTree(annotation));
-    return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
+    if (annotation != null) {
+      var dataNode = new JsonApiData(id, FdoType.ANNOTATION.getName(),
+          mapper.valueToTree(annotation));
+      return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
+    }
+    log.warn("Unable to find annotation {}", id);
+    throw new NotFoundException("Unable to find annotation " + id);
   }
 
   public JsonApiWrapper getAnnotationByVersion(String id, int version, String path)

--- a/src/main/java/eu/dissco/backend/service/DigitalMediaService.java
+++ b/src/main/java/eu/dissco/backend/service/DigitalMediaService.java
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.backend.database.jooq.enums.JobState;
 import eu.dissco.backend.database.jooq.enums.MjrTargetType;
 import eu.dissco.backend.domain.DigitalMediaFull;
-import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.FdoType;
+import eu.dissco.backend.domain.MasJobRequest;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinksFull;
@@ -54,12 +54,17 @@ public class DigitalMediaService {
     return wrapResponse(dataNodePlusOne, pageNumber, pageSize, path);
   }
 
-  public JsonApiWrapper getDigitalMediaById(String id, String path) {
+  public JsonApiWrapper getDigitalMediaById(String id, String path) throws NotFoundException {
     var mediaObject = repository.getLatestDigitalMediaObjectById(id);
-    var dataNode = new JsonApiData(mediaObject.getDctermsIdentifier(),
-        FdoType.DIGITAL_MEDIA.getName(), mediaObject, mapper);
-    var linksNode = new JsonApiLinks(path);
-    return new JsonApiWrapper(dataNode, linksNode);
+    if (mediaObject != null) {
+      var dataNode = new JsonApiData(mediaObject.getDctermsIdentifier(),
+          FdoType.DIGITAL_MEDIA.getName(), mediaObject, mapper);
+      var linksNode = new JsonApiLinks(path);
+      return new JsonApiWrapper(dataNode, linksNode);
+    }
+    log.warn("Unable to find digital media {}", id);
+    throw new NotFoundException("Unable to find digital media " + id);
+
   }
 
   public JsonApiListResponseWrapper getAnnotationsOnDigitalMedia(String mediaId, String path) {

--- a/src/main/java/eu/dissco/backend/service/DigitalSpecimenService.java
+++ b/src/main/java/eu/dissco/backend/service/DigitalSpecimenService.java
@@ -90,12 +90,17 @@ public class DigitalSpecimenService {
     return wrapListResponse(elasticSearchResults, pageSize, pageNumber, path);
   }
 
-  public JsonApiWrapper getSpecimenById(String id, String path) {
+  public JsonApiWrapper getSpecimenById(String id, String path) throws NotFoundException {
     var digitalSpecimen = repository.getLatestSpecimenById(id);
-    var dataNode = new JsonApiData(digitalSpecimen.getDctermsIdentifier(),
-        FdoType.DIGITAL_SPECIMEN.getName(), digitalSpecimen,
-        mapper);
-    return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
+    if (digitalSpecimen != null) {
+      var dataNode = new JsonApiData(digitalSpecimen.getDctermsIdentifier(),
+          FdoType.DIGITAL_SPECIMEN.getName(), digitalSpecimen,
+          mapper);
+      return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
+    } else {
+      log.warn("Unable to find specimen {}", id);
+      throw new NotFoundException("Unable to find specimen " + id);
+    }
   }
 
   public JsonApiWrapper getSpecimenByIdFull(String id, String path) {

--- a/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/AnnotationControllerTest.java
@@ -82,7 +82,7 @@ class AnnotationControllerTest {
   }
 
   @Test
-  void testGetAnnotation() {
+  void testGetAnnotation() throws NotFoundException {
     var expectedResponse = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH);
     given(service.getAnnotation(ID, ANNOTATION_PATH)).willReturn(expectedResponse);
     given(applicationProperties.getBaseUrl()).willReturn("https://sandbox.dissco.tech");

--- a/src/test/java/eu/dissco/backend/controller/DigitalMediaControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/DigitalMediaControllerTest.java
@@ -84,7 +84,7 @@ class DigitalMediaControllerTest {
   }
 
   @Test
-  void testGetLatestDigitalMediaObjectById() {
+  void testGetLatestDigitalMediaObjectById() throws NotFoundException {
     // Given
     given(service.getDigitalMediaById(ID, DIGITAL_MEDIA_PATH)).willReturn(
         givenDigitalMediaJsonResponse(DIGITAL_MEDIA_PATH, ID));

--- a/src/test/java/eu/dissco/backend/controller/DigitalSpecimenControllerTest.java
+++ b/src/test/java/eu/dissco/backend/controller/DigitalSpecimenControllerTest.java
@@ -34,6 +34,7 @@ import eu.dissco.backend.domain.openapi.shared.MasSchedulingRequest;
 import eu.dissco.backend.domain.openapi.shared.MasSchedulingRequest.MasSchedulingData;
 import eu.dissco.backend.domain.openapi.shared.MasSchedulingRequest.MasSchedulingData.MasSchedulingAttributes;
 import eu.dissco.backend.exceptions.ConflictException;
+import eu.dissco.backend.exceptions.NotFoundException;
 import eu.dissco.backend.properties.ApplicationProperties;
 import eu.dissco.backend.service.DigitalSpecimenService;
 import java.util.List;
@@ -86,7 +87,7 @@ class DigitalSpecimenControllerTest {
   }
 
   @Test
-  void testGetSpecimenById() {
+  void testGetSpecimenById() throws NotFoundException {
     // When
     var result = controller.getSpecimenById(PREFIX, SUFFIX, mockRequest);
 

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -23,6 +23,7 @@ import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationResponseLis
 import static eu.dissco.backend.utils.AnnotationUtils.givenAnnotationResponseSingleDataNode;
 import static eu.dissco.backend.utils.AnnotationUtils.givenBatchMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -188,7 +189,7 @@ class AnnotationServiceTest {
   }
 
   @Test
-  void testGetAnnotation() {
+  void testGetAnnotation() throws NotFoundException {
     // Given
     var expected = givenAnnotationResponseSingleDataNode(ANNOTATION_PATH);
     given(repository.getAnnotation(ID)).willReturn(givenAnnotationResponse(ID));
@@ -198,6 +199,14 @@ class AnnotationServiceTest {
 
     // Then
     assertThat(expected).isEqualTo(result);
+  }
+
+  @Test
+  void testGetAnnotationNotFound() {
+    // Given
+
+    // When / Then
+    assertThrows(NotFoundException.class, () -> service.getAnnotation(ID, ANNOTATION_PATH));
   }
 
   @ParameterizedTest

--- a/src/test/java/eu/dissco/backend/service/DigitalMediaServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalMediaServiceTest.java
@@ -125,7 +125,7 @@ class DigitalMediaServiceTest {
   }
 
   @Test
-  void testGetDigitalMediaById() {
+  void testGetDigitalMediaById() throws NotFoundException {
     // Given
     var mediaObject = givenDigitalMediaObject(ID);
     given(repository.getLatestDigitalMediaObjectById(ID)).willReturn(mediaObject);
@@ -139,6 +139,16 @@ class DigitalMediaServiceTest {
     // Then
     assertThat(responseReceived).isEqualTo(expected);
   }
+
+  @Test
+  void testGetDigitalMediaByIdNotFound() {
+    // Given
+
+    // When / Then
+    assertThrows(NotFoundException.class,
+        () -> service.getDigitalMediaById(ID, DIGITAL_MEDIA_PATH));
+  }
+
 
   @Test
   void testGetAnnotationsOnDigitalMedia() {

--- a/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
@@ -201,7 +201,7 @@ class DigitalSpecimenServiceTest {
   }
 
   @Test
-  void testGetSpecimenById() {
+  void testGetSpecimenById() throws NotFoundException {
     // Given
     var dataNode = givenDigitalSpecimenJsonApiData(givenDigitalSpecimenWrapper(ID));
     given(repository.getLatestSpecimenById(ID)).willReturn(givenDigitalSpecimenWrapper(ID));
@@ -214,6 +214,17 @@ class DigitalSpecimenServiceTest {
     assertThat(result).isEqualTo(expected);
   }
 
+
+  @Test
+  void testGetSpecimenByIdNotFound() {
+    // Given
+    given(repository.getLatestSpecimenById(ID)).willReturn(null);
+
+    // When / Then
+    assertThrows(NotFoundException.class, () -> service.getSpecimenById(ID, ANNOTATION_PATH));
+
+  }
+
   @Test
   void testGetSpecimenByIdFull() {
     // Given
@@ -221,7 +232,8 @@ class DigitalSpecimenServiceTest {
     var digitalMedia = List.of(new DigitalMediaFull(givenDigitalMediaObject(ID), List.of()));
     var annotations = List.of(givenAnnotationResponse(USER_ID_TOKEN, ID));
     given(repository.getLatestSpecimenById(ID)).willReturn(digitalSpecimen);
-    given(digitalMediaService.getFullDigitalMediaFromSpecimen(digitalSpecimen)).willReturn(digitalMedia);
+    given(digitalMediaService.getFullDigitalMediaFromSpecimen(digitalSpecimen)).willReturn(
+        digitalMedia);
     given(annotationService.getAnnotationForTargetObject(ID)).willReturn(annotations);
     var attributeNode = MAPPER.valueToTree(
         new DigitalSpecimenFull(digitalSpecimen,
@@ -289,13 +301,14 @@ class DigitalSpecimenServiceTest {
   }
 
   @Test
-  void testGetDigitalMediaFromSpecimen(){
+  void testGetDigitalMediaFromSpecimen() {
     // Given
     given(repository.getLatestSpecimenById(ID)).willReturn(givenDigitalSpecimenWrapper(ID));
     given(digitalMediaService.getDigitalMediaFromSpecimen(givenDigitalSpecimenWrapper(ID)))
         .willReturn(List.of(givenDigitalMediaObject(ID_ALT)));
     var expected = new JsonApiListResponseWrapper(
-        List.of(new JsonApiData(ID_ALT, FdoType.DIGITAL_MEDIA.getName(), givenDigitalMediaObject(ID_ALT), MAPPER)),
+        List.of(new JsonApiData(ID_ALT, FdoType.DIGITAL_MEDIA.getName(),
+            givenDigitalMediaObject(ID_ALT), MAPPER)),
         new JsonApiLinksFull(SPECIMEN_PATH)
     );
 
@@ -373,7 +386,7 @@ class DigitalSpecimenServiceTest {
     var params = new HashMap<String, List<String>>();
     params.put("q", List.of("Leucanthemum ircutianum"));
     params.put("pageNumber", List.of("2"));
-    var path = SPECIMEN_PATH+"?q=Leucanthemum ircutianum";
+    var path = SPECIMEN_PATH + "?q=Leucanthemum ircutianum";
     var map = new MultiValueMapAdapter<>(params);
     var mappedParam = Map.of("q", List.of("Leucanthemum ircutianum"));
     given(elasticRepository.search(mappedParam, pageNum, pageSize)).willReturn(
@@ -424,7 +437,7 @@ class DigitalSpecimenServiceTest {
     var params = new LinkedHashMap<String, List<String>>();
     params.put("country", List.of("France", "Albania"));
     params.put("typeStatus", List.of("holotype"));
-    var path = SPECIMEN_PATH+"?country=France&country=Albania&typeStatus=holotype";
+    var path = SPECIMEN_PATH + "?country=France&country=Albania&typeStatus=holotype";
     var map = new MultiValueMapAdapter<>(params);
     var mappedParam = Map.of(
         "ods:hasEvents.ods:hasLocation.dwc:country.keyword",


### PR DESCRIPTION
Annotation, Digital Media, and Digital Specimens now return a 404 instead of a 500 NPE
[Jira](https://naturalis.atlassian.net/browse/DD-1852?atlOrigin=eyJpIjoiMjZlY2FlZDdjMjU0NGZlMDhmNzY0OThiMzA2NWY2MzgiLCJwIjoiaiJ9)