### PR TITLE
Feature/es uses search after

### DIFF
--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -78,12 +78,16 @@ public class DigitalSpecimenController extends BaseController {
     return ResponseEntity.ok(specimen);
   }
 
+  /**
+   * @deprecated
+   */
   @Operation(summary = "Get latest paginated digital specimens")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "Digital specimens successfully retrieved", content = {
           @Content(mediaType = "application/json", schema = @Schema(implementation = DigitalSpecimenResponseList.class))
       })
   })
+  @Deprecated(since = "1.1.3", forRemoval = true)
   @GetMapping(value = "/latest", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<JsonApiListResponseWrapper> getLatestSpecimen(
       @Parameter(description = PAGE_NUM_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_NUM) int pageNumber,

--- a/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
+++ b/src/main/java/eu/dissco/backend/controller/DigitalSpecimenController.java
@@ -74,7 +74,7 @@ public class DigitalSpecimenController extends BaseController {
       @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
       HttpServletRequest request) throws IOException {
     log.info("Received get request for specimen");
-    var specimen = service.getSpecimen(pageNumber, pageSize, getPath(request));
+    var specimen = service.getLatestSpecimens(pageNumber, pageSize, getPath(request));
     return ResponseEntity.ok(specimen);
   }
 
@@ -90,7 +90,7 @@ public class DigitalSpecimenController extends BaseController {
       @Parameter(description = PAGE_SIZE_OAS) @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
       HttpServletRequest request) throws IOException {
     log.info("Received get request for latest digital specimen");
-    var specimens = service.getLatestSpecimen(pageNumber, pageSize, getPath(request));
+    var specimens = service.getLatestSpecimens(pageNumber, pageSize, getPath(request));
     return ResponseEntity.ok(specimens);
   }
 

--- a/src/main/java/eu/dissco/backend/service/AnnotationService.java
+++ b/src/main/java/eu/dissco/backend/service/AnnotationService.java
@@ -3,6 +3,7 @@ package eu.dissco.backend.service;
 import static eu.dissco.backend.domain.FdoType.ANNOTATION;
 import static eu.dissco.backend.service.DigitalServiceUtils.createVersionNode;
 import static eu.dissco.backend.utils.HandleProxyUtils.HANDLE_PROXY;
+import static eu.dissco.backend.utils.ServiceUtils.hasNext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -173,11 +174,11 @@ public class AnnotationService {
     var elasticSearchResults = elasticRepository.getAnnotationsForCreator(orcid, pageNumber,
         pageSize);
     var annotationList = elasticSearchResults.getRight();
-    var dataNodePlusOne = annotationList.stream().map(annotation ->
+    var dataNode = annotationList.stream().map(annotation ->
         new JsonApiData(annotation.getId(), FdoType.ANNOTATION.getName(),
             mapper.valueToTree(annotation))).toList();
-    return JsonApiUtils.wrapListResponse(dataNodePlusOne, elasticSearchResults.getLeft(),
-        pageSize, pageNumber, path);
+    return JsonApiUtils.wrapListResponse(dataNode, elasticSearchResults.getLeft(),
+        pageSize, pageNumber, path, hasNext(pageNumber, pageSize, elasticSearchResults.getLeft()));
   }
 
   public JsonApiWrapper getAnnotationVersions(String id, String path) throws NotFoundException {

--- a/src/main/java/eu/dissco/backend/utils/JsonApiUtils.java
+++ b/src/main/java/eu/dissco/backend/utils/JsonApiUtils.java
@@ -29,4 +29,14 @@ public class JsonApiUtils {
     var metaNode = new JsonApiMeta(totalCount);
     return new JsonApiListResponseWrapper(dataNode, linksNode, metaNode);
   }
+
+  public static JsonApiListResponseWrapper wrapListResponse(
+      List<JsonApiData> dataNode, long totalCount,
+      int pageSize, int pageNumber, String path, boolean hasNext) {
+    var linksNode = new JsonApiLinksFull(pageNumber, pageSize, hasNext, path);
+    var metaNode = new JsonApiMeta(totalCount);
+    return new JsonApiListResponseWrapper(dataNode, linksNode, metaNode);
+  }
+
+
 }

--- a/src/main/java/eu/dissco/backend/utils/ServiceUtils.java
+++ b/src/main/java/eu/dissco/backend/utils/ServiceUtils.java
@@ -1,0 +1,14 @@
+package eu.dissco.backend.utils;
+
+public class ServiceUtils {
+
+  private ServiceUtils() {
+    // Utility class
+  }
+
+  public static boolean hasNext(int pageNumber, int pageSize, Long totalResults) {
+    var objectsCounted = pageNumber * pageSize;
+    return objectsCounted < totalResults;
+  }
+
+}

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -212,14 +213,16 @@ class ElasticSearchRepositoryIT {
     assertThat(result.getRight()).isEqualTo(List.of(targetSpecimen));
   }
 
-  @Test
-  void testSearchSecondPage() throws IOException {
+  @ParameterizedTest
+  @ValueSource(ints = {10, 8})
+  void testSearchSecondPage(int totalResults) throws IOException {
     // Given
     int pageNumber = 2;
     int pageSize = 5;
+    var expectedResultsSize = totalResults % pageSize == 0 ? pageSize : totalResults % pageSize;
     List<DigitalSpecimen> specimenTestRecords = new ArrayList<>();
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < totalResults; i++) {
       var specimen = givenDigitalSpecimenWrapper(DOI + PREFIX + "/" + i);
       specimenTestRecords.add(specimen);
     }
@@ -231,8 +234,8 @@ class ElasticSearchRepositoryIT {
         pageSize);
 
     // Then
-    assertThat(responseReceived.getLeft()).isEqualTo(10L);
-    assertThat(responseReceived.getRight()).hasSize(pageSize);
+    assertThat(responseReceived.getLeft()).isEqualTo(totalResults);
+    assertThat(responseReceived.getRight()).hasSize(expectedResultsSize);
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
+++ b/src/test/java/eu/dissco/backend/repository/ElasticSearchRepositoryIT.java
@@ -212,28 +212,6 @@ class ElasticSearchRepositoryIT {
     assertThat(result.getRight()).isEqualTo(List.of(targetSpecimen));
   }
 
-
-  @Test
-  void testGetSpecimens() throws Exception {
-    // Given
-    int pageNumber = 0;
-    int pageSize = 10;
-    long totalHits = 15L;
-    var digitalSpecimens = new ArrayList<DigitalSpecimen>();
-    for (int i = 0; i < totalHits; i++) {
-      String id = DOI + PREFIX + "/" + i;
-      digitalSpecimens.add(givenDigitalSpecimenWrapper(id));
-    }
-    postDigitalSpecimens(parseToElasticFormat(digitalSpecimens));
-
-    // When
-    var responseReceived = repository.getSpecimens(pageNumber, pageSize);
-
-    // Then
-    assertThat(responseReceived.getLeft()).isEqualTo(totalHits);
-    assertThat(responseReceived.getRight()).hasSize(pageSize + 1);
-  }
-
   @Test
   void testSearchSecondPage() throws IOException {
     // Given
@@ -379,23 +357,25 @@ class ElasticSearchRepositoryIT {
     var givenSpecimens = new ArrayList<DigitalSpecimen>();
     var responseExpected = new ArrayList<DigitalSpecimen>();
 
-    for (int i = 0; i < pageSize + 1; i++) {
-      var specimen = givenDigitalSpecimenWrapper(DOI + PREFIX + "/" + i);
+    for (int i = 0; i < pageSize; i++) {
+      var id = DOI + PREFIX + "/" + (char) i;
+      var specimen = givenDigitalSpecimenWrapper(id);
       responseExpected.add(
-          givenDigitalSpecimenSourceSystem(DOI + PREFIX + "/" + i, SOURCE_SYSTEM_ID_1));
+          givenDigitalSpecimenSourceSystem(id, SOURCE_SYSTEM_ID_1));
       givenSpecimens.add(specimen);
     }
     for (int i = pageSize; i < pageSize * 2; i++) {
-      var specimen = givenDigitalSpecimenWrapper(DOI + PREFIX + "/" + i);
+      var id = DOI + PREFIX + "/" + (char) i;
+      var specimen = givenDigitalSpecimenWrapper(id);
       givenSpecimens.add(specimen);
     }
     postDigitalSpecimens(parseToElasticFormat(givenSpecimens));
 
     // When
-    var responseReceived = repository.getLatestSpecimen(pageNumber, pageSize);
+    var responseReceived = repository.getLatestSpecimens(pageNumber, pageSize);
 
     // Then
-    assertThat(responseReceived.getRight()).hasSize(11).hasSameElementsAs(responseExpected);
+    assertThat(responseReceived.getRight()).hasSize(10).hasSameElementsAs(responseExpected);
   }
 
   @Test
@@ -420,7 +400,7 @@ class ElasticSearchRepositoryIT {
     postDigitalSpecimens(parseToElasticFormat(givenSpecimens));
 
     // When
-    var responseReceived = repository.getLatestSpecimen(pageNumber, pageSize);
+    var responseReceived = repository.getLatestSpecimens(pageNumber, pageSize);
 
     // Then
     assertThat(responseReceived.getRight()).hasSize(pageSize).hasSameElementsAs(responseExpected);
@@ -439,8 +419,8 @@ class ElasticSearchRepositoryIT {
     List<Annotation> givenAnnotations = new ArrayList<>();
     List<Annotation> expected = new ArrayList<>();
     for (long i = 0; i < totalHits; i++) {
-      String id = HANDLE + PREFIX + "/" + i;
-      if (i <= pageSize) {
+      String id = HANDLE + PREFIX + "/" + (char) i;
+      if (i < pageSize) {
         expected.add(givenAnnotationResponse(id, USER_ID_TOKEN));
       }
       givenAnnotations.add(givenAnnotationResponse(id, USER_ID_TOKEN));
@@ -454,7 +434,7 @@ class ElasticSearchRepositoryIT {
 
     // Then
     assertThat(responseReceived.getLeft()).isEqualTo(totalHits);
-    assertThat(responseReceived.getRight()).isEqualTo(expected);
+    assertThat(responseReceived.getRight()).hasSize(10).hasSameElementsAs(expected);
   }
 
   @Test

--- a/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/AnnotationServiceTest.java
@@ -114,7 +114,7 @@ class AnnotationServiceTest {
     var expected = new JsonApiListResponseWrapper(tmp.getData(), tmp.getLinks(),
         new JsonApiMeta(totalCount));
     given(elasticRepository.getAnnotationsForCreator(ORCID, pageNumber, pageSize))
-        .willReturn(Pair.of(totalCount, givenAnnotationResponseList(annotationId, pageSize + 1)));
+        .willReturn(Pair.of(totalCount, givenAnnotationResponseList(annotationId, pageSize)));
 
     // When
     var received = service.getAnnotationsForUser(ORCID, pageNumber, pageSize, path);

--- a/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
@@ -95,92 +95,50 @@ class DigitalSpecimenServiceTest {
   }
 
   @Test
-  void testGetSpecimen() throws Exception {
-    // Given
-    int pageNum = 1;
-    int pageSize = 10;
-    var digitalSpecimens = givenDigitalSpecimenList(pageSize + 1);
-    var totalResults = 20L;
-    var dataNode = givenDigitalSpecimenJsonApiData(digitalSpecimens);
-    var linksNode = new JsonApiLinksFull(pageNum, pageSize, true, SPECIMEN_PATH);
-    var expected = new JsonApiListResponseWrapper(dataNode.subList(0, pageSize), linksNode,
-        new JsonApiMeta(totalResults));
-    given(elasticRepository.getSpecimens(pageNum, pageSize)).willReturn(
-        Pair.of(totalResults, digitalSpecimens));
-
-    // When
-    var result = service.getSpecimen(pageNum, pageSize, SPECIMEN_PATH);
-
-    // Then
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  void testGetSpecimenLastPage() throws Exception {
-    // Given
-    int pageNum = 1;
-    int pageSize = 10;
-    var digitalSpecimens = List.of(givenDigitalSpecimenWrapper(ID));
-    var dataNode = givenDigitalSpecimenJsonApiData(digitalSpecimens);
-    var linksNode = new JsonApiLinksFull(pageNum, pageSize, false, SPECIMEN_PATH);
-    var totalResults = 10L;
-    var expected = new JsonApiListResponseWrapper(dataNode, linksNode,
-        new JsonApiMeta(totalResults));
-    given(elasticRepository.getSpecimens(pageNum, pageSize)).willReturn(
-        Pair.of(totalResults, digitalSpecimens));
-
-    // When
-    var result = service.getSpecimen(pageNum, pageSize, SPECIMEN_PATH);
-
-    // Then
-    assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  void testGetLatestSpecimen() throws IOException {
+  void testGetLatestSpecimens() throws IOException {
     // Given
     int pageSize = 10;
     int pageNum = 1;
     var totalResults = 20L;
-    var specimens = Collections.nCopies(pageSize + 1, givenDigitalSpecimenWrapper(ID));
+    var specimens = Collections.nCopies(pageSize, givenDigitalSpecimenWrapper(ID));
     var elasticSearchResults = Pair.of(totalResults, specimens);
     var dataNode = givenDigitalSpecimenJsonApiData(specimens);
-    given(elasticRepository.getLatestSpecimen(pageNum, pageSize)).willReturn(elasticSearchResults);
+    given(elasticRepository.getLatestSpecimens(pageNum, pageSize)).willReturn(elasticSearchResults);
     var expected = new JsonApiListResponseWrapper(dataNode.subList(0, pageSize),
         new JsonApiLinksFull(pageNum, pageSize, true, SPECIMEN_PATH),
         new JsonApiMeta(totalResults));
 
     // When
-    var result = service.getLatestSpecimen(pageNum, pageSize, SPECIMEN_PATH);
+    var result = service.getLatestSpecimens(pageNum, pageSize, SPECIMEN_PATH);
 
     // Then
     assertThat(result).isEqualTo(expected);
   }
 
   @Test
-  void testGetLatestSpecimenPage2() throws IOException {
+  void testGetLatestSpecimensPage2() throws IOException {
     // Given
     int pageSize = 10;
     int pageNum = 2;
     var totalResults = 20L;
-    var specimens = Collections.nCopies(pageSize + 1, givenDigitalSpecimenWrapper(ID));
+    var specimens = Collections.nCopies(pageSize, givenDigitalSpecimenWrapper(ID));
     var elasticSearchResults = Pair.of(totalResults, specimens);
     var dataNode = givenDigitalSpecimenJsonApiData(specimens);
     var path = SPECIMEN_PATH + "?pageNumber=" + pageNum;
-    given(elasticRepository.getLatestSpecimen(pageNum, pageSize)).willReturn(elasticSearchResults);
+    given(elasticRepository.getLatestSpecimens(pageNum, pageSize)).willReturn(elasticSearchResults);
     var expected = new JsonApiListResponseWrapper(dataNode.subList(0, pageSize),
         new JsonApiLinksFull(pageNum, pageSize, true, path),
         new JsonApiMeta(totalResults));
 
     // When
-    var result = service.getLatestSpecimen(pageNum, pageSize, path);
+    var result = service.getLatestSpecimens(pageNum, pageSize, path);
 
     // Then
     assertThat(result).isEqualTo(expected);
   }
 
   @Test
-  void testGetLatestSpecimenLastPage() throws IOException {
+  void testGetLatestSpecimensLastPage() throws IOException {
     // Given
     int pageSize = 10;
     int pageNum = 2;
@@ -188,13 +146,13 @@ class DigitalSpecimenServiceTest {
     var specimens = Collections.nCopies(pageSize, givenDigitalSpecimenWrapper(ID));
     var elasticSearchResults = Pair.of(totalResults, specimens);
     var dataNode = givenDigitalSpecimenJsonApiData(specimens);
-    given(elasticRepository.getLatestSpecimen(pageNum, pageSize)).willReturn(elasticSearchResults);
+    given(elasticRepository.getLatestSpecimens(pageNum, pageSize)).willReturn(elasticSearchResults);
     var expected = new JsonApiListResponseWrapper(dataNode,
         new JsonApiLinksFull(pageNum, pageSize, false, SPECIMEN_PATH),
         new JsonApiMeta(totalResults));
 
     // When
-    var result = service.getLatestSpecimen(pageNum, pageSize, SPECIMEN_PATH);
+    var result = service.getLatestSpecimens(pageNum, pageSize, SPECIMEN_PATH);
 
     // Then
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/DigitalSpecimenServiceTest.java
@@ -120,7 +120,7 @@ class DigitalSpecimenServiceTest {
     // Given
     int pageSize = 10;
     int pageNum = 2;
-    var totalResults = 20L;
+    var totalResults = 22L;
     var specimens = Collections.nCopies(pageSize, givenDigitalSpecimenWrapper(ID));
     var elasticSearchResults = Pair.of(totalResults, specimens);
     var dataNode = givenDigitalSpecimenJsonApiData(specimens);
@@ -321,7 +321,7 @@ class DigitalSpecimenServiceTest {
   }
 
   @Test
-  void testSearch() throws IOException, UnknownParameterException {
+  void testSearchHasNext() throws IOException, UnknownParameterException {
     // Given
     int pageNum = 1;
     int pageSize = 10;
@@ -331,10 +331,10 @@ class DigitalSpecimenServiceTest {
     params.put("q", List.of("Leucanthemum ircutianum"));
     var map = new MultiValueMapAdapter<>(params);
     given(elasticRepository.search(anyMap(), eq(pageNum), eq(pageSize))).willReturn(
-        Pair.of(11L, givenDigitalSpecimenList(pageSize + 1)));
+        Pair.of(11L, givenDigitalSpecimenList(pageSize)));
     var linksNode = new JsonApiLinksFull(pageNum, pageSize, true, SPECIMEN_PATH);
     var expected = new JsonApiListResponseWrapper(digitalSpecimens.subList(0, pageSize), linksNode,
-        new JsonApiMeta(11L));
+        new JsonApiMeta(10L));
 
     // When
     var result = service.search(map, SPECIMEN_PATH);


### PR DESCRIPTION
# Changes to ElasticSearch

Because ElasticSearch doesn't support paginated queries over 10k objects, we need to change our
approach. We use the `search_after` API to cycle through a high volume of results.

This is only for searching specimens/annotations; aggregations stay the same.

1. Sort results by some field (I chose `dcterms:created`, `dcterms:identifier` as tiebreaker)
2. Check if we've reached the requested page
   a. If yes: stop searching, return result
   b. If no: take last value of the sorted field
3. Continue to search starting after the id we took from step 2b

## Why annotations?

Currently, we only use ES to search by user (creator). I thought it would be good to use the
search_after for these queries, because we may want to extend this to searching by MAS creators,
which will likely far exceed the 10k limit.

## No Search_after for ELViS?

There's an exception we'd need to consider for the ELViS endpoint. (It uses a should_ query instead
of a must_). Because we're removing the endpoint soon, I left the ELViS endpoint unchanged.

# Get Latest Specimens vs Get Any Specimens

We have 2 endpoints:

- GET specimens/v1/latest : returns latest specimens
- GET specimens/v1 : returns any specimens

Before, these two endpoints had different logic. The /latest endpoint would sort by date created,
and the regular endpoint wouldn't. Because we use the date created in our sort_by query, these two
endpoints do exactly the same thing now (and rely on the same method). The endpoints are distinct
for now, but we should remove the /latest endpoint at some point. I've marked it as deprecated for now. 

# Changes to Plus-one-to-change-next

Before, we increased the pageSize to check next in elastic queries. However, this actually results
in missed results.

If we have documents 1-18, and we query page Number = 3, page size = 5:

Expected pagination: [1 2 3 4 5] [6 7 8 9 10] [11 12 13 14 15] [16 17 18]

Expected results: [11 12 13 14 15]

If we increase page size by 1, however, pagination
becomes: [1 2 3 4 5 6] [7 8 9 10 11 12] [13 14 15 16 17 18]

Results we get: [13 14 15 16 17 18] (truncated to [13 14 15 16 17] for the user)

So we really don't want to increase the page size. (We probably also want to check this for DB
queries, but that's beyond the scope of this PR)

We can use the ElasticSearch `TotalHits` instead of increasing pageSize to check if there are more
results.