### PR TITLE
Send VirtualCollectionEvent on Create and Delete

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -5,3 +5,11 @@ CVE-2025-48976
 # Sep 5 2025
 # Issue with Netty, wait for spring boot upgrade
 CVE-2025-58056
+
+# Sept 17 2025
+# Issue with Spring Framework, needs an update of spring-boot
+CVE-2025-41248
+
+# Sept 17 2025
+# Issue with Spring Framework, needs an update of spring-boot
+CVE-2025-41249

--- a/src/main/java/eu/dissco/backend/domain/VirtualCollectionAction.java
+++ b/src/main/java/eu/dissco/backend/domain/VirtualCollectionAction.java
@@ -1,0 +1,6 @@
+package eu.dissco.backend.domain;
+
+public enum VirtualCollectionAction {
+  CREATE,
+  DELETE
+}

--- a/src/main/java/eu/dissco/backend/domain/VirtualCollectionEvent.java
+++ b/src/main/java/eu/dissco/backend/domain/VirtualCollectionEvent.java
@@ -1,0 +1,9 @@
+package eu.dissco.backend.domain;
+
+import eu.dissco.backend.schema.VirtualCollection;
+
+public record VirtualCollectionEvent(
+    VirtualCollectionAction action,
+    VirtualCollection virtualCollection
+) {
+}

--- a/src/main/java/eu/dissco/backend/service/RabbitMqPublisherService.java
+++ b/src/main/java/eu/dissco/backend/service/RabbitMqPublisherService.java
@@ -30,8 +30,10 @@ public class RabbitMqPublisherService {
   @Value("${rabbitmq.virtual-collection.routing-key:virtual-collection}")
   private String virtualCollectionRoutingKey;
 
-  public void publishMasRequestEvent(String routingKey, Object object) throws JsonProcessingException {
-    log.debug("Publishing new mas request with routing key: {} and with object: {}", routingKey, object);
+  public void publishMasRequestEvent(String routingKey, Object object)
+      throws JsonProcessingException {
+    log.debug("Publishing new mas request with routing key: {} and with object: {}", routingKey,
+        object);
     rabbitTemplate.convertAndSend(masExchangeName, routingKey, mapper.writeValueAsString(object));
   }
 
@@ -59,7 +61,8 @@ public class RabbitMqPublisherService {
   public void publishVirtualCollectionEvent(VirtualCollectionEvent event)
       throws JsonProcessingException {
     log.info("Publishing {} virtual-collection to queue", event.action());
-    rabbitTemplate.convertAndSend(virtualCollectionExchange, virtualCollectionRoutingKey, mapper.writeValueAsString(event));
+    rabbitTemplate.convertAndSend(virtualCollectionExchange, virtualCollectionRoutingKey,
+        mapper.writeValueAsString(event));
   }
 
 }

--- a/src/main/java/eu/dissco/backend/service/VirtualCollectionService.java
+++ b/src/main/java/eu/dissco/backend/service/VirtualCollectionService.java
@@ -59,7 +59,8 @@ public class VirtualCollectionService {
     log.info("Requesting handle for Virtual Collection: {}",
         virtualCollectionRequest.getLtcCollectionName());
     String handle = postHandle(virtualCollectionRequest);
-    var virtualCollection = buildVirtualCollection(virtualCollectionRequest, 1, agent, handle, Date.from(Instant.now()));
+    var virtualCollection = buildVirtualCollection(virtualCollectionRequest, 1, agent, handle,
+        Date.from(Instant.now()));
     repository.createVirtualCollection(virtualCollection);
     publishCreateEvent(virtualCollection, agent);
     publishVirtualCollectionEvent(new VirtualCollectionEvent(
@@ -73,7 +74,9 @@ public class VirtualCollectionService {
     try {
       rabbitMqPublisherService.publishVirtualCollectionEvent(virtualCollectionEvent);
     } catch (JsonProcessingException e) {
-      log.error("Fatal exception, unable to publish virtual collection event to RabbitMQ. Manuel action required", e);
+      log.error(
+          "Fatal exception, unable to publish virtual collection event to RabbitMQ. Manuel action required",
+          e);
     }
   }
 
@@ -109,7 +112,8 @@ public class VirtualCollectionService {
     repository.rollbackVirtualCollectionCreate(virtualCollection.getId());
   }
 
-  private VirtualCollection buildVirtualCollection(VirtualCollectionRequest virtualCollection, int version,
+  private VirtualCollection buildVirtualCollection(VirtualCollectionRequest virtualCollection,
+      int version,
       Agent agent, String handle, Date createdTimestamp) {
     var id = HANDLE_PROXY + handle;
     return new VirtualCollection()
@@ -198,7 +202,8 @@ public class VirtualCollectionService {
       String id) {
     tombstoneHandle(id);
     var timestamp = Instant.now();
-    var tombstoneVirtualCollection = buildTombstoneVirtualCollection(virtualCollection, agent, timestamp);
+    var tombstoneVirtualCollection = buildTombstoneVirtualCollection(virtualCollection, agent,
+        timestamp);
     repository.tombstoneVirtualCollection(tombstoneVirtualCollection);
     publishTombstoneEvent(agent, virtualCollection, tombstoneVirtualCollection);
     publishVirtualCollectionEvent(new VirtualCollectionEvent(DELETE, tombstoneVirtualCollection));

--- a/src/main/java/eu/dissco/backend/service/VirtualCollectionService.java
+++ b/src/main/java/eu/dissco/backend/service/VirtualCollectionService.java
@@ -1,6 +1,7 @@
 package eu.dissco.backend.service;
 
 import static eu.dissco.backend.domain.FdoType.VIRTUAL_COLLECTION;
+import static eu.dissco.backend.domain.VirtualCollectionAction.DELETE;
 import static eu.dissco.backend.service.DigitalServiceUtils.createVersionNode;
 import static eu.dissco.backend.utils.JsonApiUtils.wrapListResponse;
 import static eu.dissco.backend.utils.TombstoneUtils.buildTombstoneMetadata;
@@ -9,6 +10,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.backend.domain.FdoType;
 import eu.dissco.backend.domain.MongoCollection;
+import eu.dissco.backend.domain.VirtualCollectionAction;
+import eu.dissco.backend.domain.VirtualCollectionEvent;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiListResponseWrapper;
@@ -59,9 +62,19 @@ public class VirtualCollectionService {
     var virtualCollection = buildVirtualCollection(virtualCollectionRequest, 1, agent, handle, Date.from(Instant.now()));
     repository.createVirtualCollection(virtualCollection);
     publishCreateEvent(virtualCollection, agent);
+    publishVirtualCollectionEvent(new VirtualCollectionEvent(
+        VirtualCollectionAction.CREATE, virtualCollection));
     var dataNode = new JsonApiData(virtualCollection.getId(), FdoType.VIRTUAL_COLLECTION.getName(),
         mapper.valueToTree(virtualCollection));
     return new JsonApiWrapper(dataNode, new JsonApiLinks(path));
+  }
+
+  private void publishVirtualCollectionEvent(VirtualCollectionEvent virtualCollectionEvent) {
+    try {
+      rabbitMqPublisherService.publishVirtualCollectionEvent(virtualCollectionEvent);
+    } catch (JsonProcessingException e) {
+      log.error("Fatal exception, unable to publish virtual collection event to RabbitMQ. Manuel action required", e);
+    }
   }
 
   private String postHandle(VirtualCollectionRequest virtualCollectionRequest) {
@@ -187,10 +200,16 @@ public class VirtualCollectionService {
     var timestamp = Instant.now();
     var tombstoneVirtualCollection = buildTombstoneVirtualCollection(virtualCollection, agent, timestamp);
     repository.tombstoneVirtualCollection(tombstoneVirtualCollection);
+    publishTombstoneEvent(agent, virtualCollection, tombstoneVirtualCollection);
+    publishVirtualCollectionEvent(new VirtualCollectionEvent(DELETE, tombstoneVirtualCollection));
+    return true;
+  }
+
+  private void publishTombstoneEvent(Agent agent, VirtualCollection virtualCollection,
+      VirtualCollection tombstoneVirtualCollection) {
     try {
       rabbitMqPublisherService.publishTombstoneEvent(mapper.valueToTree(tombstoneVirtualCollection),
           mapper.valueToTree(virtualCollection), agent);
-      return true;
     } catch (JsonProcessingException e) {
       log.error("Unable to publish tombstone event to provenance service", e);
       throw new ProcessingFailedException(

--- a/src/main/java/eu/dissco/backend/service/VirtualCollectionService.java
+++ b/src/main/java/eu/dissco/backend/service/VirtualCollectionService.java
@@ -75,7 +75,7 @@ public class VirtualCollectionService {
       rabbitMqPublisherService.publishVirtualCollectionEvent(virtualCollectionEvent);
     } catch (JsonProcessingException e) {
       log.error(
-          "Fatal exception, unable to publish virtual collection event to RabbitMQ. Manuel action required",
+          "Fatal exception, unable to publish virtual collection event to RabbitMQ. Manual action required",
           e);
     }
   }

--- a/src/test/java/eu/dissco/backend/service/VirtualCollectionServiceTest.java
+++ b/src/test/java/eu/dissco/backend/service/VirtualCollectionServiceTest.java
@@ -8,6 +8,7 @@ import static eu.dissco.backend.TestUtils.ORCID;
 import static eu.dissco.backend.TestUtils.PREFIX;
 import static eu.dissco.backend.TestUtils.SUFFIX;
 import static eu.dissco.backend.TestUtils.givenAgent;
+import static eu.dissco.backend.domain.VirtualCollectionAction.DELETE;
 import static eu.dissco.backend.utils.AgentUtils.ROLE_NAME_VIRTUAL_COLLECTION;
 import static eu.dissco.backend.utils.VirtualCollectionUtils.VIRTUAL_COLLECTION_NAME;
 import static eu.dissco.backend.utils.VirtualCollectionUtils.VIRTUAL_COLLECTION_PATH;
@@ -29,6 +30,8 @@ import static org.mockito.Mockito.mockStatic;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import eu.dissco.backend.domain.MongoCollection;
+import eu.dissco.backend.domain.VirtualCollectionAction;
+import eu.dissco.backend.domain.VirtualCollectionEvent;
 import eu.dissco.backend.domain.jsonapi.JsonApiData;
 import eu.dissco.backend.domain.jsonapi.JsonApiLinks;
 import eu.dissco.backend.domain.jsonapi.JsonApiWrapper;
@@ -206,6 +209,9 @@ class VirtualCollectionServiceTest {
     then(repository).should().createVirtualCollection(virtualCollection);
     then(rabbitMqPublisherService).should()
         .publishCreateEvent(MAPPER.valueToTree(virtualCollection), agent);
+    then(rabbitMqPublisherService).should()
+        .publishVirtualCollectionEvent(
+            new VirtualCollectionEvent(VirtualCollectionAction.CREATE, virtualCollection));
     assertThat(result).isEqualTo(expected);
   }
 
@@ -249,6 +255,9 @@ class VirtualCollectionServiceTest {
     then(rabbitMqPublisherService).should()
         .publishTombstoneEvent(MAPPER.valueToTree(tombstoneVirtualCollection),
             MAPPER.valueToTree(virtualCollection), agent);
+    then(rabbitMqPublisherService).should()
+        .publishVirtualCollectionEvent(new VirtualCollectionEvent(
+            DELETE, tombstoneVirtualCollection));
     assertThat(result).isTrue();
   }
 


### PR DESCRIPTION
Send a VirtualCollectionEvent which contains the action (create or delete) and the virtualCollection.
This can be picked up by the virtual-collection-processing-service which will then take appropriate action.

https://naturalis.atlassian.net/browse/DD-1954